### PR TITLE
S3_external_reg

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -19,6 +19,7 @@
     "menu.spec.ts",
     "namespaces.spec.ts",
     "applications.spec.ts",
-    "uninstall.spec.ts"
+    "uninstall.spec.ts",
+    "s3_and_external_registry.spec.ts"
   ]
 }

--- a/cypress/integration/s3_and_external_registry.spec.ts
+++ b/cypress/integration/s3_and_external_registry.spec.ts
@@ -13,12 +13,12 @@ describe('Epinio installation testing with s3 and external registry configured',
   });
 
   it('Add the Epinio helm repo', () => {
-    cy.get('.clusters').contains('local').click()
+    topLevelMenu.clusters('local');
     cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://epinio.github.io/helm-charts'});
   });
 
   it('Install Epinio', () => {
-    cy.get('.clusters').contains('local').click()
+    topLevelMenu.clusters('local');
     cy.epinioInstall({s3: true, extRegistry: true});
   });
 
@@ -28,12 +28,12 @@ describe('Epinio installation testing with s3 and external registry configured',
   });
 
   it('Uninstall Epinio', () => {
-    cy.get('.clusters').contains('local').click()
+    topLevelMenu.clusters('local');
     cy.epinioUninstall();
   });
 
   it('Remove the Epinio helm repo', () => {
-    cy.get('.clusters').contains('local').click()
+    topLevelMenu.clusters('local');
     cy.removeHelmRepo();
   });
 });

--- a/cypress/integration/s3_and_external_registry.spec.ts
+++ b/cypress/integration/s3_and_external_registry.spec.ts
@@ -1,0 +1,39 @@
+import { Epinio } from '~/cypress/support/epinio';
+import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+
+Cypress.config();
+describe('Epinio installation testing with s3 and external registry configured', () => {
+  const topLevelMenu = new TopLevelMenu();
+  const epinio = new Epinio();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/home');
+    topLevelMenu.openIfClosed();
+  });
+
+  it('Add the Epinio helm repo', () => {
+    cy.get('.clusters').contains('local').click()
+    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://epinio.github.io/helm-charts'});
+  });
+
+  it('Install Epinio', () => {
+    cy.get('.clusters').contains('local').click()
+    cy.epinioInstall({s3: true, extRegistry: true});
+  });
+
+  it('Deploy an application to test external registry / s3', () => {
+    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.runAppTest('multipleInstance');
+  });
+
+  it('Uninstall Epinio', () => {
+    cy.get('.clusters').contains('local').click()
+    cy.epinioUninstall();
+  });
+
+  it('Remove the Epinio helm repo', () => {
+    cy.get('.clusters').contains('local').click()
+    cy.removeHelmRepo();
+  });
+});

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -18,6 +18,10 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.system_domain = process.env.SYSTEM_DOMAIN;
   config.env.cors = process.env.CORS;
   config.env.cache_session = process.env.CACHE_SESSION || false;
+  config.env.external_reg_username = process.env.EXT_REG_USER;
+  config.env.external_reg_password = process.env.EXT_REG_PASSWORD;
+  config.env.s3_key_id = process.env.S3_KEY_ID;
+  config.env.s3_key_secret = process.env.S3_KEY_SECRET;
 
   return config;
 };

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -208,7 +208,7 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl}) => {
   cy.clickClusterMenu(['Apps & Marketplace', 'Repositories'])
 
   // Make sure we are in Repositories page and we can see the Create button
-  cy.get('h1').contains('Repositories');
+  cy.contains('header', 'Repositories', {timeout: 8000}).should('be.visible');
   cy.contains('Create').should('be.visible');
 
   cy.clickButton('Create');
@@ -221,6 +221,11 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl}) => {
 // Install Epinio via Helm
 Cypress.Commands.add('epinioInstall', ({s3=false, extRegistry=false}) => {
   cy.clickClusterMenu(['Apps & Marketplace', 'Charts']);
+  
+  // Make sure we are in the chart screen (test failed here before)
+  cy.contains('header', 'Charts', {timeout: 8000}).should('be.visible');
+  
+  // Install epinio-installer chart
   cy.contains('epinio-installer').click();
   cy.contains('Charts: epinio-installer').should('be.visible');
   cy.clickButton('Install');
@@ -240,7 +245,7 @@ Cypress.Commands.add('epinioInstall', ({s3=false, extRegistry=false}) => {
   cy.contains('ingress controller').click();
 
   // Configure external registry
-  if (extRegistry) {
+  if (extRegistry === true) {
     cy.contains('a', 'External registry').click();
     cy.contains('Use an external registry').click();
     cy.typeValue({label: 'External registry url', value: 'registry.hub.docker.com'});
@@ -250,7 +255,7 @@ Cypress.Commands.add('epinioInstall', ({s3=false, extRegistry=false}) => {
   }
 
   // Configure s3 storage
-  if (s3) {
+  if (s3 === true) {
     cy.contains('a', 'External S3 storage').click();
     cy.contains('Use an external s3 storage').click();
     cy.typeValue({label: 'S3 Endpoint', value: 's3.amazonaws.com'});
@@ -277,7 +282,8 @@ Cypress.Commands.add('epinioUninstall', () => {
 
 // Remove the Epinio Helm repo
 Cypress.Commands.add('removeHelmRepo', () => {
-  cy.clickClusterMenu(['Apps & Marketplace', 'Repositories'])
+  cy.clickClusterMenu(['Apps & Marketplace', 'Repositories']);
+  cy.contains('header', 'Repositories', {timeout: 8000}).should('be.visible');
   cy.contains('epinio-repo').click();
   // Using three dots menu to delete the repo
   // TODO: Check if we can click checkbox instead

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -219,8 +219,8 @@ Cypress.Commands.add('addHelmRepo', ({repoName, repoUrl}) => {
 });
 
 // Install Epinio via Helm
-Cypress.Commands.add('epinioInstall', () => {
-  cy.clickClusterMenu(['Apps & Marketplace', 'Charts'])
+Cypress.Commands.add('epinioInstall', ({s3=false, extRegistry=false}) => {
+  cy.clickClusterMenu(['Apps & Marketplace', 'Charts']);
   cy.contains('epinio-installer').click();
   cy.contains('Charts: epinio-installer').should('be.visible');
   cy.clickButton('Install');
@@ -238,6 +238,27 @@ Cypress.Commands.add('epinioInstall', () => {
   // Cert Manager and ingress controler already installed by Rancher
   cy.contains('CertManager').click();
   cy.contains('ingress controller').click();
+
+  // Configure external registry
+  if (extRegistry) {
+    cy.contains('a', 'External registry').click();
+    cy.contains('Use an external registry').click();
+    cy.typeValue({label: 'External registry url', value: 'registry.hub.docker.com'});
+    cy.typeValue({label: 'External registry username', value: Cypress.env('external_reg_username')});
+    cy.typeValue({label: 'External registry password', value: Cypress.env('external_reg_password')});
+    cy.typeValue({label: 'External registry namespace', value: 'juadk'});
+  }
+
+  // Configure s3 storage
+  if (s3) {
+    cy.contains('a', 'External S3 storage').click();
+    cy.contains('Use an external s3 storage').click();
+    cy.typeValue({label: 'S3 Endpoint', value: 's3.amazonaws.com'});
+    cy.typeValue({label: 'S3 access key id', value: Cypress.env('s3_key_id')});
+    cy.typeValue({label: 'S3 access key secret', value: Cypress.env('s3_key_secret')});
+    cy.typeValue({label: 'S3 Bucket', value: 'epinio-ci'});
+    cy.contains('S3 use SSL').click();
+  }
 
   // Install and check we get successfull installation message with a timeout long enough
   cy.clickButton('Install');

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -21,7 +21,7 @@ declare global {
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string,): Chainable<Element>;
       removeHelmRepo(): Chainable<Element>;
-      epinioInstall(): Chainable<Element>;
+      epinioInstall(s3?: boolean, extRegistry?: boolean,): Chainable<Element>;
       epinioUninstall(): Chainable<Element>;
 
       // Functions declared in tests.ts

--- a/cypress/support/toplevelmenu.ts
+++ b/cypress/support/toplevelmenu.ts
@@ -19,8 +19,8 @@ export class TopLevelMenu {
     cy.get('.side-menu .option');
   }
 
-  clusters() {
-    cy.get('.clusters .cluster.selector.option');
+  clusters(clusterName: string) {
+    cy.get('.clusters .cluster.selector.option').contains(clusterName).click();
   }
 
   localization() {


### PR DESCRIPTION
Fix #46 
This PR adds a new test where s3 and external registry are configured in the installation screen.
It also adds robustness by fixing two part of codes where tests fail sporadically.

![image](https://user-images.githubusercontent.com/6025636/149226140-55394eaf-d7e6-4c4c-a041-d5aa67153a0b.png)
