### PR TITLE
Add services tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -17,8 +17,9 @@
     "first_connexion.spec.ts",
     "installation.spec.ts",
     "menu.spec.ts",
-    "namespaces.spec.ts",
     "applications.spec.ts",
+    "services.spec.ts",
+    "namespaces.spec.ts",
     "uninstall.spec.ts",
     "s3_and_external_registry.spec.ts"
   ]

--- a/cypress/integration/applications.spec.ts
+++ b/cypress/integration/applications.spec.ts
@@ -14,18 +14,18 @@ describe('Applications testing', () => {
   });
 
   it('Push a 5 instances application into default namespace and check it', () => {
-    cy.runAppTest('multipleInstance');
+    cy.runApplicationsTest('multipleInstance');
   });
 
   it('Push application with custom route into default namespace and check it', () => {
-    cy.runAppTest('customRoute');
+    cy.runApplicationsTest('customRoute');
   });
 
   it('Push application with env vars into default namespace and check it', () => {
-    cy.runAppTest('envVars');
+    cy.runApplicationsTest('envVars');
   });
 
   it('Push a 5 instances application with custom route and env vars into default namespace and check it', () => {
-    cy.runAppTest('allTests');
+    cy.runApplicationsTest('allTests');
   });
 });

--- a/cypress/integration/applications.spec.ts
+++ b/cypress/integration/applications.spec.ts
@@ -2,7 +2,7 @@ import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
 
 Cypress.config();
-describe('Application testing', () => {
+describe('Applications testing', () => {
   const topLevelMenu = new TopLevelMenu();
   const epinio = new Epinio();
 

--- a/cypress/integration/namespaces.spec.ts
+++ b/cypress/integration/namespaces.spec.ts
@@ -14,10 +14,10 @@ describe('Namespaces testing', () => {
   });
 
   it('Push and check an application into the created namespace', () => {
-    cy.runNamespaceTest('newNamespace');
+    cy.runNamespacesTest('newNamespace');
   });
 
   it('Try to push an application without any namespace', () => {
-    cy.runNamespaceTest('withoutNamespace');
+    cy.runNamespacesTest('withoutNamespace');
   });
 });

--- a/cypress/integration/namespaces.spec.ts
+++ b/cypress/integration/namespaces.spec.ts
@@ -2,7 +2,7 @@ import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
 
 Cypress.config();
-describe('Namespace testing', () => {
+describe('Namespaces testing', () => {
   const topLevelMenu = new TopLevelMenu();
   const epinio = new Epinio();
 

--- a/cypress/integration/s3_and_external_registry.spec.ts
+++ b/cypress/integration/s3_and_external_registry.spec.ts
@@ -24,7 +24,7 @@ describe('Epinio installation testing with s3 and external registry configured',
 
   it('Deploy an application to test external registry / s3', () => {
     epinio.accessEpinioMenu(Cypress.env('cluster'));
-    cy.runAppTest('multipleInstance');
+    cy.runApplicationsTest('multipleInstance');
   });
 
   it('Uninstall Epinio', () => {

--- a/cypress/integration/services.spec.ts
+++ b/cypress/integration/services.spec.ts
@@ -16,31 +16,11 @@ describe('Services testing', () => {
     epinio.accessEpinioMenu(Cypress.env('cluster'));
   });
 
-  it('Create a new service', () => {
-    cy.createService({serviceName: service});
+  it('Create an application with a service, unbind the service and delete all', () => {
+    cy.runServicesTest('newAppWithService');
   });
 
-  it('Create an application with the newly created service', () => {
-    cy.createApp({appName: appName, archiveName: archive, serviceName: service});
-    cy.checkApp({appName: appName, checkService: true});
-  });
-
-  it('Unbind and delete the created service', () => {
-    cy.deleteService({serviceName: service});
-    cy.checkApp({appName: appName});
-  });
-
-  it('Create another new service', () => {
-    cy.createService({serviceName: anotherService});
-  });
-
-  it('Bind the created service to the application', () => {
-    cy.bindService({appName: appName, serviceName: anotherService});
-    cy.checkApp({appName: appName, checkService: true});
-  });
-
-  it('Delete the application and the service', () => {
-    cy.deleteApp({appName: appName});
-    cy.deleteService({serviceName: anotherService});
+  it('Bind a created service to an existing application and delete all', () => {
+    cy.runServicesTest('bindServiceOnApp');
   });
 });

--- a/cypress/integration/services.spec.ts
+++ b/cypress/integration/services.spec.ts
@@ -1,0 +1,46 @@
+import { Epinio } from '~/cypress/support/epinio';
+import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+
+Cypress.config();
+describe('Services testing', () => {
+  const topLevelMenu = new TopLevelMenu();
+  const epinio = new Epinio();
+  const appName = 'testapp';
+  const archive = 'sample-app.tar.gz';
+  const service = 'service01';
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/home');
+    topLevelMenu.openIfClosed();
+    epinio.accessEpinioMenu(Cypress.env('cluster'));
+  });
+
+  it('Create a new service', () => {
+    cy.createService({serviceName: service});
+  });
+
+  it('Create an application with the newly created service', () => {
+    cy.createApp({appName: appName, archiveName: archive, serviceName: service});
+    cy.checkApp({appName: appName, checkService: true});
+  });
+
+  it('Unbind and delete the created service', () => {
+    cy.deleteService({serviceName: service});
+    cy.checkApp({appName: appName});
+  });
+
+  it('Create another new service', () => {
+    cy.createService({serviceName: anotherService});
+  });
+
+  it('Bind the created service to the application', () => {
+    cy.bindService({appName: appName, serviceName: anotherService});
+    cy.checkApp({appName: appName, checkService: true});
+  });
+
+  it('Delete the application and the service', () => {
+    cy.deleteApp({appName: appName});
+    cy.deleteService({serviceName: anotherService});
+  });
+});

--- a/cypress/support/epinio.ts
+++ b/cypress/support/epinio.ts
@@ -14,8 +14,8 @@ export class Epinio {
 
   accessEpinioMenu(cluster: string) {
     cy.contains('Epinio').click();
-    cy.contains('Epinio instances', {timeout: 5000}).should('be.visible') && cy.contains('Available').should('be.visible');
-     cy.contains(cluster).click();
+    cy.contains('Epinio instances', {timeout: 8000}).should('be.visible') && cy.contains('Available').should('be.visible');
+    cy.contains(cluster).click();
   }
 
   firstLogin() {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -30,8 +30,9 @@ declare global {
       epinioUninstall(): Chainable<Element>;
 
       // Functions declared in tests.ts
-      runAppTest(testName: string,): Chainable<Element>;
-      runNamespaceTest(testName: string,): Chainable<Element>;
+      runApplicationsTest(testName: string,): Chainable<Element>;
+      runServicesTest(testName: string,): Chainable<Element>;
+      runNamespacesTest(testName: string,): Chainable<Element>;
     }
 }}
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -6,7 +6,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       // Functions declared in functions.ts
-      login(username?: string, password?: string, cacheSession?: boolean): Chainable<Element>;
+      login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;
       clickMenu(label: string,): Chainable<Element>;
@@ -14,11 +14,16 @@ declare global {
       confirmDelete(namespace?: string,): Chainable<Element>;
       checkStageStatus(numIndex: number, timeout?: number, status?: string,): Chainable<Element>;
       typeValue(label: string, value: string, noLabel?: boolean,): Chainable<Element>;
-      createApp(appName: string, archiveName: string, route?: string, addVar?:boolean, instanceNum?: number, shouldBeDisabled?: boolean,): Chainable<Element>;
-      checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean): Chainable<Element>;
+      typeKeyValue(key: string, value: string,): Chainable<Element>;
+      getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
+      createApp(appName: string, archiveName: string, route?: string, addVar?:boolean, instanceNum?: number, serviceName?: string, shouldBeDisabled?: boolean,): Chainable<Element>;
+      checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkService?: boolean): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
+      createService(serviceName: string, namespace?: string,): Chainable<Element>;
+      deleteService(serviceName: string, namespace?: string,): Chainable<Element>;
+      bindService(appName: string, serviceName: string, namespace?: string,): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string,): Chainable<Element>;
       removeHelmRepo(): Chainable<Element>;
       epinioInstall(s3?: boolean, extRegistry?: boolean,): Chainable<Element>;

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -27,7 +27,7 @@ Cypress.Commands.add('runAppTest', (testName: string) => {
   }
 
   // Delete the tested application
-  cy.deleteApp({appName: appName})
+  cy.deleteApp({appName: appName});
 });
 
 // Namespaces tests

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -1,7 +1,7 @@
 import './functions';
 
 // Applications tests
-Cypress.Commands.add('runAppTest', (testName: string) => {
+Cypress.Commands.add('runApplicationsTest', (testName: string) => {
   const appName = 'testapp';
   const archive = 'sample-app.tar.gz';
   const customRoute = 'custom-route-' + appName + '.' + Cypress.env('system_domain');
@@ -30,8 +30,49 @@ Cypress.Commands.add('runAppTest', (testName: string) => {
   cy.deleteApp({appName: appName});
 });
 
+// Services tests
+Cypress.Commands.add('runServicesTest', (testName: string) => {
+  const appName = 'testapp';
+  const archive = 'sample-app.tar.gz'
+  const service = 'service01';
+
+  switch (testName) {
+    case 'newAppWithService':
+      // Create a new service
+      cy.createService({serviceName: service});
+
+      // Create an application with the newly created service and check it
+      cy.createApp({appName: appName, archiveName: archive, serviceName: service});
+      cy.checkApp({appName: appName, checkService: true});
+
+      // Unbind and delete the created service
+      cy.deleteService({serviceName: service});
+      cy.checkApp({appName: appName});
+
+      // Delete the tested application
+      cy.deleteApp({appName: appName});
+      break;
+    case 'bindServiceOnApp':
+      // Create another new service
+      cy.createService({serviceName: service});
+
+      // Create an application *WITHOUT* any service
+      cy.createApp({appName: appName, archiveName: archive});
+      cy.checkApp({appName: appName});
+
+      // Bind the created service to the application and check it
+      cy.bindService({appName: appName, serviceName: service});
+      cy.checkApp({appName: appName, checkService: true});
+
+      // Delete the tested application and the service
+      cy.deleteApp({appName: appName});
+      cy.deleteService({serviceName: service});
+      break;
+  }
+});
+
 // Namespaces tests
-Cypress.Commands.add('runNamespaceTest', (testName: string) => {
+Cypress.Commands.add('runNamespacesTest', (testName: string) => {
   const appName = 'testapp';
   const archive = 'sample-app.tar.gz';
   const defaultNamespace = 'workspace';


### PR DESCRIPTION
Add tests for the `Services` menu.

This should fix #34, #35, #36, #38, #39 and #40.

Without the `services` functions:
![Screenshot from 2022-01-13 00-22-59](https://user-images.githubusercontent.com/25102165/149339452-c689cf5f-2d74-4636-8ac0-8bd5cf23f8ea.png)

With the `services` functions:
![Screenshot from 2022-01-13 12-48-03](https://user-images.githubusercontent.com/25102165/149339457-9873a9fc-a756-4b10-a208-36416101defa.png)

**NOTE:** the `it` messages have been modified in the latest version, to be more verbose.