### PR TITLE
Add user option for firefox browser

### DIFF
--- a/.github/workflows/master_ui_workflow.yml
+++ b/.github/workflows/master_ui_workflow.yml
@@ -17,6 +17,10 @@ on:
         description: Scenario to test
         required: true
         type: string
+      docker_options:
+        description: Set other docker options
+        required: false
+        type: string
       runner:
         description: Runner on which to execute tests
         required: true
@@ -73,7 +77,7 @@ jobs:
         S3_KEY_ID: ${{ secrets.s3_key_id }}
         S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
-      options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }}
+      options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }} ${{ inputs.docker_options }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/scenario_2_cypress_firefox.yml
+++ b/.github/workflows/scenario_2_cypress_firefox.yml
@@ -14,6 +14,9 @@ jobs:
       browser: firefox
       cypress_image: cypress/browsers:node16.13.0-chrome95-ff94
       cypress_test: install_with_s3_and_external_registry.spec.ts
+      # Due to security reason, Firefox can't be started as root
+      # https://github.com/cypress-io/github-action#firefox
+      docker_options: '--user 1001'
       runner: ui-e2e-2
     secrets:
       ext_reg_user: secrets.DOCKER_USER


### PR DESCRIPTION
Current Firefox test fails with:
```
Can't run because you've entered an invalid browser name.

Browser: 'firefox' was not found on your system or is not supported by Cypress.

Cypress supports the following browsers:
- chrome
- chromium
- edge
- electron
- firefox

You can also use a custom browser: https://on.cypress.io/customize-browsers

Available browsers found on your system are:
- chrome
- electron
```
https://github.com/cypress-io/github-action#firefox
We must specify --user 1001 for starting Firefox