### PR TITLE
Add Firefox test back

### DIFF
--- a/.github/workflows/master_ui_workflow.yml
+++ b/.github/workflows/master_ui_workflow.yml
@@ -17,6 +17,10 @@ on:
         description: Scenario to test
         required: true
         type: string
+      docker_options:
+        description: Set other docker options
+        required: false
+        type: string
       runner:
         description: Runner on which to execute tests
         required: true
@@ -73,7 +77,7 @@ jobs:
         S3_KEY_ID: ${{ secrets.s3_key_id }}
         S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
-      options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }}
+      options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }} ${{ inputs.docker_options }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/scenario_2_cypress_firefox.yml
+++ b/.github/workflows/scenario_2_cypress_firefox.yml
@@ -1,5 +1,5 @@
 # This workflow calls the master UI workflow with custom variables
-name: Scenario 2 Cypress chrome
+name: Scenario 2 Cypress firefox
 
 on:
   workflow_dispatch:
@@ -11,9 +11,12 @@ jobs:
   call-master-UI-workflow:
     uses: ./.github/workflows/master_ui_workflow.yml
     with:
-      browser: chrome
+      browser: firefox
       cypress_image: cypress/browsers:node16.13.0-chrome95-ff94
       cypress_test: install_with_s3_and_external_registry.spec.ts
+      # Due to security reason, Firefox can't be started as root
+      # https://github.com/cypress-io/github-action#firefox
+      docker_options: '--user 1000'
       runner: ui-e2e-2
     secrets:
       ext_reg_user: secrets.DOCKER_USER

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
-[![Scenario 1](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_1_cypress_chrome.yml/badge.svg)](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_1_cypress_chrome.yml)
-[![Scenario 2](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_2_cypress_chrome.yml/badge.svg)](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_2_cypress_chrome.yml)
+[![Scenario 1 - chrome](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_1_cypress_chrome.yml/badge.svg)](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_1_cypress_chrome.yml)
+[![Scenario 2 - firefox](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_2_cypress_firefox.yml/badge.svg)](https://github.com/epinio/epinio-end-to-end-tests/actions/workflows/scenario_2_cypress_firefox.yml)
 # epinio-end-to-end-tests
 This repository contains all the files necessary to run Epinio end-to-end tests.
 
 In the cypress directory are stored the tests written using the [Cypress](https://www.cypress.io/) testing framework.
 
 Tests are executed every night in the CI. For now, two scenarios are tested.
-### Scenario 1
+### Scenario 1 - Using Chrome
 In this first scenario, Epinio is deployed with default options. </br>
 You can check all the things we test directly in the [file](./cypress/integration/scenarios/install_with_default_options.spec.ts).
 
-### Scenario 2
+### Scenario 2 - Using Firefox
 Second scenario tests Epinio installation with S3 and external registry configured. </br>
 Unlike the first scenario, we only play a small bunch of [tests](./cypress/integration/scenarios/install_with_s3_and_external_registry.spec.ts).
 
-For now, both scenarios are executed on Chrome. </br>
-Later, we will execute Scenario 2 on Firefox instead.
 ## Running the tests
 
 __Attention__, Epinio is using Rancher UI but Epinio will get its own UI in the coming weeks.


### PR DESCRIPTION
Code added by https://github.com/epinio/epinio-end-to-end-tests/pull/70 didn't work because we should have deleted cache in our self-hosted runner.
After doing more tests in my lab, it seems it works now.