### PR TITLE
Use k3s v1.21 + permissions fixes

### DIFF
--- a/.github/workflows/master_ui_workflow.yml
+++ b/.github/workflows/master_ui_workflow.yml
@@ -48,6 +48,7 @@ jobs:
           DASHBOARD_VERSION: epinio-v0.3.6
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
+          K3S_VERSION: v1.21.9+k3s1
         run: |
           export MY_HOSTNAME=$(hostname)
           make e2e-ci

--- a/.github/workflows/master_ui_workflow.yml
+++ b/.github/workflows/master_ui_workflow.yml
@@ -117,7 +117,9 @@ jobs:
     steps:
       - name: Delete k3s cluster
         run: |
-          sudo /usr/local/bin/k3s-uninstall.sh
+          /usr/local/bin/k3s-uninstall.sh
           helm repo remove rancher-stable jetstack
-          sudo chown -R sles:users /home/sles/actions-runner/_work/epinio-end-to-end-tests/epinio-end-to-end-tests/cypress/*
+          LOCAL_USER=$(id -un)
+          LOCAL_GROUP=$(id -gn)
+          sudo chown -R ${LOCAL_USER}:${LOCAL_GROUP} /home/${LOCAL_USER}/actions-runner/_work/epinio-end-to-end-tests/epinio-end-to-end-tests/cypress/*
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,7 @@ install-helm: ## Install Helm
 	sudo rm -rf linux-amd64/ helm-*.tar.gz
 
 install-k3s: ## Install k3s with default options
-	curl -sfL https://get.k3s.io | sh -
-	sudo chmod 644 /etc/rancher/k3s/k3s.yaml
+	curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} sh -s - --write-kubeconfig-mode 644
 	## Wait for k3s to start (could be improved)
 	sleep 120
 


### PR DESCRIPTION
Tested on my local GH runner: https://github.com/ldevulder/epinio-end-to-end-tests/actions/runs/1843749909

Step 2 fails because I don't have a proper Docker configuration, but this PR is about K3s installation/uninstallation and these steps are OK.