### PR TITLE
Delete sample service at the end of tests

### DIFF
--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -70,6 +70,9 @@ Cypress.Commands.add('runServicesTest', (testName: string) => {
 
       // Delete the tested application
       cy.deleteApp({appName: appName});
+      
+      // Delete the created service
+      cy.deleteService({serviceName: service});
       break;
     case 'bindServiceOnApp':
       // Create another new service


### PR DESCRIPTION
Sample service has to be deleted at the end of the newAppWithService test. 
Otherwise, test fails with message 'Service service01 already exists'
Failed test: https://github.com/epinio/epinio-end-to-end-tests/runs/5332222495?check_suite_focus=true