### PR TITLE
Wait one second after typing env vars

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -130,6 +130,9 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
     cy.get('.key > input').should('have.value', 'PORT');
     cy.get('.no-resize').should('have.value', '8080');
   }
+  // The following wait is mandatory, otherwise, env variables are not seen...
+  // Don't know yet if something more elegant can be done.
+  cy.wait(1000);
 
   // Set the desired number of instances
   cy.typeValue({label: 'Instances', value: instanceNum});


### PR DESCRIPTION
Cypress is going too fast after having typed env vars, so when the application is fully deployed, we don't see `Environment Vars` set to 1 and the test fails.
This PR adds a wait call of 1 second, that's probably not the more elegant way but it does the job until we find something better.