### PR TITLE
Fix create app issue in Cypress

### DIFF
--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -40,6 +40,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.checkApp({appName: appName, checkVar: true});
       break;
     case 'restartAndRebuild':
+      cy.wait(5000); // Workaround for https://github.com/rancher/dashboard/issues/5240
       cy.createApp({appName: appName, archiveName: archive});
       cy.checkApp({appName: appName});
       cy.restartApp({appName: appName});


### PR DESCRIPTION
Try to fix:

```
1) Applications testing
       Push basic application and check we can restart and rebuild it:
     CypressError: Timed out retrying after 10050ms: `cy.click()` failed because this element:

`<a href="/dashboard/ext/epinio/c/local/applications/createapp" class="btn role-primary">Create</a>`

is being covered by another element:

`<p data-v-27e7b68e="">Request...</p>`

Fix this problem, or use {force: true} to disable error checking.

https://on.cypress.io/element-cannot-be-interacted-with
      at $Cy.ensureDescendents (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:164036:78)
      at ensureDescendents (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:150250:8)
      at ensureDescendentsAndScroll (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:150257:14)
      at ensureElIsNotCovered (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:150389:5)
      at runAllChecks (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:150579:52)
      at retryActionability (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:150603:16)
      at tryCatcher (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:13022:23)
      at Function.Promise.attempt.Promise.try (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:10296:29)
      at whenStable (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:168760:63)
      at https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:168257:14
      at tryCatcher (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:13022:23)
      at Promise._settlePromiseFromHandler (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:10957:31)
      at Promise._settlePromise (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:11014:18)
      at Promise._settlePromise0 (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:11059:10)
      at Promise._settlePromises (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:[111](https://github.com/epinio/epinio-end-to-end-tests/runs/5498014773?check_suite_focus=true#step:3:111)39:18)
      at Promise._fulfill (https://tf6-gha-runner-1/__cypress/runner/cypress_runner.js:11083:18)
  From Your Spec Code:
      at Context.eval (https://tf6-gha-runner-1/__cypress/tests?p=cypress/support/index.ts:2796:36)
```

![image](https://user-images.githubusercontent.com/6025636/157708656-e8a485bc-b3e2-46a0-ba2d-d5c3f9285ab7.png)
