### PR TITLE
Disable restart and rebuild tests

### DIFF
--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -37,11 +37,12 @@ describe('Applications testing', () => {
     topLevelMenu.openIfClosed();
     epinio.accessEpinioMenu(Cypress.env('cluster'));
   });
-
+// Temporarly removing restart and rebuild test, not enough stable with CI
+/*
   it('Push basic application and check we can restart and rebuild it', () => {
     cy.runApplicationsTest('restartAndRebuild');
   });
-
+*/
   it('Push a 5 instances application with container image into default namespace and check it', () => {
     cy.runApplicationsTest('multipleInstanceAndContainer');
   });

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -12,11 +12,12 @@ describe('Applications testing', () => {
     topLevelMenu.openIfClosed();
     epinio.accessEpinioMenu(Cypress.env('cluster'));
   });
-
+// Temporarly removing restart and rebuild test, not enough stable with CI
+/*
   it('Push basic application and check we can restart and rebuild it', () => {
     cy.runApplicationsTest('restartAndRebuild');
   });
-
+*/
   it('Push a 5 instances application with a container image into default namespace and check it', () => {
     cy.runApplicationsTest('multipleInstanceAndContainer');
   });


### PR DESCRIPTION
The restart test is not stable enough, it breaks CI so It needs improvements.
I remove it temporary while I'm doing investigations.