### PR TITLE
Test app log and app shell buttons

### DIFF
--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -21,7 +21,7 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('multipleInstanceAndContainer');
   });
 
-  it('Push application with custom route into default namespace and check it', () => {
+  it('Push application with custom route into default namespace and check app log/shell features', () => {
     cy.runApplicationsTest('customRoute');
   });
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -295,6 +295,53 @@ Cypress.Commands.add('rebuildApp', ({appName, namespace='workspace'}) => {
   cy.get('header', {timeout: 60000}).should('contain', appName).and('contain', 'Running');
 });
 
+// Check application logs
+Cypress.Commands.add('showAppLog', ({appName, namespace='workspace'}) => {
+  cy.clickEpinioMenu('Applications');
+  
+  // Go to application details
+  cy.getDetail({name: appName, type: 'applications', namespace: namespace});
+
+  // Make sure we are in the details page
+  cy.get('header').should('contain', 'Applications:').and('contain', appName);
+
+  // Select the 3dots button and show logs
+  cy.get('div.actions > .role-multi-action').click();
+  cy.contains('li', 'App Logs').click();
+
+  // A new tab must appear
+  cy.get('.tab-label').should('contain', 'testapp - App Logs');
+  
+  // Web server ready message must appear in the log
+  cy.contains('ready to handle connections');
+  cy.get('.tab > .closer').click();
+});
+
+// Check application shell
+Cypress.Commands.add('showAppShell', ({appName, namespace='workspace'}) => {
+  cy.clickEpinioMenu('Applications');
+  
+  // Go to application details
+  cy.getDetail({name: appName, type: 'applications', namespace: namespace});
+
+  // Make sure we are in the details page
+  cy.get('header').should('contain', 'Applications:').and('contain', appName);
+
+  // Select the 3dots button and show logs
+  cy.get('div.actions > .role-multi-action').click();
+  cy.contains('li', 'App Shell').click();
+
+  // A new tab must appear
+  cy.get('.tab-label').should('contain', 'testapp - App Shell');
+  
+  // Make sure we can run ls command in the shell
+  cy.contains('Connected');
+  cy.get('.terminal').type('ls{enter}');
+  // Record a screenshot and close the tab
+  cy.get('.terminal').screenshot('record_ls_command_output');
+  cy.get('.tab > .closer').click();
+});
+
 // Namespace functions
 
 // Create an Epinio namespace

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -21,6 +21,8 @@ declare global {
       deleteApp(appName: string, state?: string,): Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;
       rebuildApp(appName: string, namespace?: string,): Chainable<Element>;
+      showAppLog(appName: string, namespace?: string,): Chainable<Element>;
+      showAppShell(appName: string, namespace?: string,): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
       createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -34,6 +34,10 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
     case 'customRoute':
       cy.createApp({appName: appName, archiveName: archive, route: customRoute});
       cy.checkApp({appName: appName, route: customRoute});
+      /* App log and app shell are disabled until https://github.com/epinio/epinio-end-to-end-tests/issues/126 is fixed.
+      cy.showAppLog({appName: appName});
+      cy.showAppShell({appName: appName});
+      */
       break;
     case 'envVarsAndGitUrl':
       cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, addVar: 'ui', sourceType: 'Git URL'});


### PR DESCRIPTION
Fix #129 and fix #128 

This [code](https://github.com/epinio/epinio-end-to-end-tests/pull/130/files#diff-aa81749832032471ec95581351571f6effa7d9b9c2ae35ebdf7ffae4fb70cd38R37-R40) is voluntary commented because we are blocked by https://github.com/epinio/epinio-end-to-end-tests/issues/126

However, I successfully tested these functions in my local Cypress lab.