### PR TITLE
Adapt code for new application source types

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install K3s / Helm / Rancher
         id: installation
         env:
-          DASHBOARD_VERSION: epinio-v0.6.0
+          DASHBOARD_VERSION: epinio-dev
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
           K3S_VERSION: v1.22.7+k3s1

--- a/.github/workflows/master_std_ui_workflow.yml
+++ b/.github/workflows/master_std_ui_workflow.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install K3s / Helm / Rancher / Epinio
         id: installation
         env:
-          DASHBOARD_VERSION: epinio-v0.6.0
+          DASHBOARD_VERSION: epinio-dev
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
           K3S_VERSION: v1.22.7+k3s1

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -61,8 +61,29 @@ Cypress.Commands.add('confirmDelete', (namespace) => {
 });
 
 // Check the status of the running stage
-Cypress.Commands.add('checkStageStatus', ({numIndex, timeout=6000, status='Success'}) => {
+Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, status='Success'}) => {
   var getScope = ':nth-child(' + numIndex + ') > .col-badge-state-formatter > .status > .badge';
+  if (sourceType == 'Container Image') {
+    if (numIndex === 2) {
+      cy.get('.tab-label').should('contain', 'testapp - App Logs');
+      cy.contains('Command line: \'httpd -D FOREGROUND\'', {timeout: timeout});
+      cy.get('.tab > .closer').click(); 
+    }
+  } else {
+      if (numIndex === 3) {
+        cy.get('.tab-label').should('contain', 'testapp - Build');
+        cy.contains('buildpack: _ _ __ ___ _____ Done', {timeout: timeout});
+        cy.get('.tab > .closer').click();
+      
+        /* Ugly thing here...
+        When step 3 (building is done), it automatically opens a new App logs tab
+        and it hides the success badge of step 3...
+        So we have to wait last step done before continuing */
+        cy.get('.tab-label').should('contain', 'testapp - App Logs');
+        if (sourceType != 'Git URL') cy.contains('ready to handle connections', {timeout: timeout});
+        cy.get('.tab > .closer').click();
+      }      
+  }
   cy.get(getScope, {timeout: timeout}).contains(status).should('be.visible');
 });
 
@@ -166,11 +187,11 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         cy.typeValue({label: 'Image', value: archiveName}); 
         break;
       case 'Git URL':
-      cy.typeValue({label: 'URL', value: archiveName});
-      cy.typeValue({label: 'Branch', value: 'main'});
+        cy.typeValue({label: 'URL', value: archiveName});
+        cy.typeValue({label: 'Branch', value: 'main'}); 
         break;
       case 'Archive':
-    cy.get('input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});
+        cy.get('input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});
         break; 
     };
   };
@@ -196,9 +217,9 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
 
   // Check that each steps are succesfully done
   cy.checkStageStatus({numIndex: 1});
-  cy.checkStageStatus({numIndex: 2, timeout: 120000});
+  cy.checkStageStatus({numIndex: 2, timeout: 240000, sourceType});
   if (sourceType !== 'Container Image') {
-    cy.checkStageStatus({numIndex: 3, timeout: 240000});
+    cy.checkStageStatus({numIndex: 3, timeout: 240000, sourceType});
     cy.checkStageStatus({numIndex: 4, timeout: 240000});
   }
 
@@ -272,13 +293,13 @@ Cypress.Commands.add('restartApp', ({appName, namespace='workspace'}) => {
   cy.get('header').should('contain', 'Applications:').and('contain', appName);
 
   // Select the 3dots button and edit configuration
-  cy.get('.role-multi-action').click();
+  cy.get('div.actions > .role-multi-action').click()
   cy.contains('li', 'Restart').click(); 
 
-  // Restart counter is not ready yet so we can not use it for now.
-  // I tried to check that instances number is not equal to 100% because
-  // it's expected as new instances are popping to replace the olders.
-  // But at the end, it adds flakyness, we wait for the restart counter to be ready.
+  // Handle application log tab
+  cy.get('.tab-label').should('contain', 'testapp - App Logs');
+  cy.contains('ready to handle connections', {timeout: 120000});
+  cy.get('.tab > .closer').click();
 });
 
 Cypress.Commands.add('rebuildApp', ({appName, namespace='workspace'}) => {
@@ -291,11 +312,16 @@ Cypress.Commands.add('rebuildApp', ({appName, namespace='workspace'}) => {
   cy.get('header').should('contain', 'Applications:').and('contain', appName);
 
   // Select the 3dots button and edit configuration
-  cy.get('.role-multi-action').click();
+  cy.get('div.actions > .role-multi-action').click()
   cy.contains('li', 'Rebuild').click(); 
 
   // Make sure the app is rebuilding and then, back to running status
   cy.get('header').should('contain', appName).and('contain', 'Building');
+  
+  cy.get('.tab-label').should('contain', 'testapp - Build');
+  cy.contains('buildpack: Reusing layers from image', {timeout: 120000});
+  cy.get('.tab > .closer').click();
+
   cy.get('header', {timeout: 60000}).should('contain', appName).and('contain', 'Running');
 });
 
@@ -457,7 +483,7 @@ Cypress.Commands.add('unbindConfiguration', ({appName, configurationName, namesp
   // Application status should be equal to 1/1
   cy.get('[data-title="Status"]', {timeout: 16000}).should('contain', '1/1');
   cy.wait(2000);
- });
+});
 
 // Bind a configuration to an existing application
 Cypress.Commands.add('bindConfiguration', ({appName, configurationName, namespace='workspace'}) => {
@@ -470,7 +496,7 @@ Cypress.Commands.add('bindConfiguration', ({appName, configurationName, namespac
   cy.get('header').should('contain', 'Applications:').and('contain', appName);
 
   // Select the 3dots button and edit configuration
-  cy.get('.role-multi-action').click();
+  cy.get('div.actions > .role-multi-action').click()
   cy.contains('Edit Config').click();
 
   // Select the Configurations tab

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -161,15 +161,19 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
   if (sourceType) {
     cy.get('.labeled-select').click();
     cy.contains(sourceType, {timeout: 120000}).click();
-    if (sourceType === 'Container Image') cy.typeValue({label: 'Image', value: archiveName});
-    if (sourceType === 'Git URL') {
+    switch (sourceType) {
+      case 'Container Image':
+        cy.typeValue({label: 'Image', value: archiveName}); 
+        break;
+      case 'Git URL':
       cy.typeValue({label: 'URL', value: archiveName});
       cy.typeValue({label: 'Branch', value: 'main'});
-    }
-  } else {
-    // Use the default one and upload the test application
+        break;
+      case 'Archive':
     cy.get('input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});
-  }
+        break; 
+    };
+  };
 
   // Use a custom Paketo Build Image if needed
   if (customPaketoImage) {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -12,7 +12,7 @@ declare global {
       clickEpinioMenu(label: string,): Chainable<Element>;
       clickClusterMenu(listLabel: string[],): Chainable<Element>;
       confirmDelete(namespace?: string,): Chainable<Element>;
-      checkStageStatus(numIndex: number, timeout?: number, status?: string,): Chainable<Element>;
+      checkStageStatus(numIndex: number, sourceType: string, timeout?: number, status?: string,): Chainable<Element>;
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -16,7 +16,7 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
-      createApp(appName: string, archiveName: string, sourceType?: string, customPaketoImage?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean,): Chainable<Element>;
+      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean,): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -32,7 +32,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.checkApp({appName: appName, dontCheckRouteAccess: true});
       break;
     case 'customRoute':
-      cy.createApp({appName: appName, archiveName: archive, route: customRoute});
+      cy.createApp({appName: appName, archiveName: archive, route: customRoute, sourceType: 'Archive'});
       cy.checkApp({appName: appName, route: customRoute});
       /* App log and app shell are disabled until https://github.com/epinio/epinio-end-to-end-tests/issues/126 is fixed.
       cy.showAppLog({appName: appName});
@@ -44,7 +44,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.checkApp({appName: appName, checkVar: true});
       break;
     case 'restartAndRebuild':
-      cy.createApp({appName: appName, archiveName: archive});
+      cy.createApp({appName: appName, archiveName: archive, sourceType: 'Archive'});
       cy.checkApp({appName: appName});
       cy.restartApp({appName: appName});
       cy.checkApp({appName: appName});
@@ -74,7 +74,7 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
       cy.createConfiguration({configurationName: configuration});
 
       // Create an application with the newly created configuration and check it
-      cy.createApp({appName: appName, archiveName: archive, configurationName: configuration});
+      cy.createApp({appName: appName, archiveName: archive, configurationName: configuration, sourceType: 'Archive'});
       cy.checkApp({appName: appName, checkConfiguration: true});
 
       // Unbind the created configuration
@@ -93,7 +93,7 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
       cy.createConfiguration({configurationName: configuration, fromFile: true});
 
       // Create an application *WITHOUT* any configuration
-      cy.createApp({appName: appName, archiveName: archive, addVar: 'file'});
+      cy.createApp({appName: appName, archiveName: archive, addVar: 'file', sourceType: 'Archive'});
       cy.checkApp({appName: appName});
 
       // Bind the created configuration to the application and check it
@@ -124,7 +124,7 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       cy.createNamespace(namespace);
 
       // Create an application on the new namespace and check it
-      cy.createApp({appName: appName, archiveName: archive});
+      cy.createApp({appName: appName, archiveName: archive, sourceType: 'Archive'});
       cy.checkApp({appName: appName, namespace: namespace});
 
       // Delete the namespace


### PR DESCRIPTION
 Fix #126 
 Fix #131 

 This PR addresses few issues which need to be fixed together to be well tested:

- [x] There is a new application source type (Folder) and this is the default choice, that means Cypress has to select Archive type as it doesn't support plain folder upload.
<img width="300" alt="image" src="https://user-images.githubusercontent.com/6025636/163390890-3fdf1537-8e1e-407d-8899-fa54c46d895e.png">

- [x] Bump  DASHBOARD_VERSION to `epinio-dev`
- [x] Adapt application creation process to handle new log tabs
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/6025636/163391134-f2628f8f-36a2-42df-bf5b-8e9483411b03.png">
