### PR TITLE
Use git repo to deploy Epinio

### DIFF
--- a/cypress/integration/scenarios/install_with_default_options.spec.ts
+++ b/cypress/integration/scenarios/install_with_default_options.spec.ts
@@ -20,7 +20,7 @@ describe('Epinio installation with default options', () => {
 
   it('Add the Epinio helm repo', () => {
     topLevelMenu.clusters(Cypress.env('cluster'));
-    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://epinio.github.io/helm-charts'});
+    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://github.com/epinio/helm-charts', repoType: 'git'});
   });
 
   it('Install Epinio', () => {

--- a/cypress/integration/scenarios/install_with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/install_with_s3_and_external_registry.spec.ts
@@ -20,7 +20,7 @@ describe('Epinio installation testing with s3 and external registry configured',
 
   it('Add the Epinio helm repo', () => {
     topLevelMenu.clusters(Cypress.env('cluster'));
-    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://epinio.github.io/helm-charts'});
+    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://github.com/epinio/helm-charts', repoType: 'git'});
   });
 
   it('Install Epinio', () => {

--- a/cypress/integration/unit_tests/installation.spec.ts
+++ b/cypress/integration/unit_tests/installation.spec.ts
@@ -14,7 +14,7 @@ describe('Epinio installation testing', () => {
   });
 
   it('Add the Epinio helm repo', () => {
-    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://epinio.github.io/helm-charts'});
+    cy.addHelmRepo({repoName: 'epinio-repo', repoUrl: 'https://github.com/epinio/helm-charts', repoType: 'git'});
   });
 
   it('Install Epinio', () => {


### PR DESCRIPTION
Before this PR, we installed Epinio (in the Rancher UI)  using the official helm repo, that means we could only test released helm chart. It does not make a lot of sense, we need to test before releasing.

Instead of using the Helm repo, we can use a git URL to target the main version of our Helm Chart, that's so much better and this PR brings that.