### PR TITLE
[Cypress] - Replace deprecated experimentalSessionSupport option

### DIFF
--- a/cypress-with-epinio-cert.json
+++ b/cypress-with-epinio-cert.json
@@ -1,5 +1,5 @@
 {
-  "experimentalSessionSupport": true,
+  "experimentalSessionAndOrigin": true,
   "defaultCommandTimeout": 10000,
   "clientCertificates": [
     {

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "experimentalSessionSupport": true,
+  "experimentalSessionAndOrigin": true,
   "defaultCommandTimeout": 10000,
   "clientCertificates": [
     {


### PR DESCRIPTION
This PR addresses this Cypress comment:
```
The experimentalSessionSupport configuration option was removed in Cypress version 9.6.0 and replaced with 
experimentalSessionAndOrigin. Please update your config to use experimentalSessionAndOrigin instead.
```