### PR TITLE
Make the code working on the std UI

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -99,6 +99,7 @@ jobs:
         S3_KEY_ID: ${{ secrets.s3_key_id }}
         S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
+        UI: rancher
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
 
@@ -183,6 +184,7 @@ jobs:
         RANCHER_PASSWORD: rancherpassword
         RANCHER_URL: https://${{ needs.installation.outputs.MY_HOSTNAME }}/dashboard
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
+        UI: rancher
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
 
@@ -222,7 +224,7 @@ jobs:
       - name: Delete k3s cluster
         if: always()
         run: |
-          make clean
+          make clean-all
 
       - name: Clean all
         if: always()

--- a/.github/workflows/master_std_ui_workflow.yml
+++ b/.github/workflows/master_std_ui_workflow.yml
@@ -99,13 +99,12 @@ jobs:
     container:
       image: ${{ inputs.cypress_image }}
       env:
-        CLUSTER_NAME: local
         CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
         EXT_REG_USER: ${{ secrets.ext_reg_user }}
         EXT_REG_PASSWORD: ${{ secrets.ext_reg_password }}
         RANCHER_USER: admin
-        RANCHER_PASSWORD: rancherpassword
-        RANCHER_URL: https://${{ needs.installation.outputs.MY_HOSTNAME }}/dashboard
+        RANCHER_PASSWORD: password
+        RANCHER_URL: https://epinio.${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
         S3_KEY_ID: ${{ secrets.s3_key_id }}
         S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
@@ -151,7 +150,7 @@ jobs:
       - name: Delete k3s cluster
         if: always()
         run: |
-          make clean
+          make clean-k3s
 
       - name: Clean all
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,15 @@ uninstall-epinio: ## Uninstall Epinio with Helm
 get-ca: ## Configure Cypress to use the epinio-ca
 	@./scripts/get_ca.sh
 
-prepare-e2e-ci: install-k3s install-helm install-rancher install-epinio get-ca ## Tests
-
 prepare-e2e-ci-rancher: install-k3s install-helm install-rancher get-ca ## Tests
 
-prepare-e2e-ci-standalone: install-k3s install-helm install-rancher install-epinio get-ca ## Tests
+prepare-e2e-ci-standalone: install-k3s install-helm install-cert-manager install-epinio get-ca ## Tests
 
-clean:
+clean-k3s:
 	/usr/local/bin/k3s-uninstall.sh
-	/usr/local/bin/helm repo remove rancher-stable jetstack
+
+clean-all: clean-k3s
+	/usr/local/bin/helm repo remove rancher-latest jetstack
 
 help: ## Show this Makefile's help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/cypress/integration/scenarios/install_with_default_options.spec.ts
+++ b/cypress/integration/scenarios/install_with_default_options.spec.ts
@@ -1,3 +1,5 @@
+// This test is only used for testing Epinio in Rancher UI
+
 import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
 
@@ -14,7 +16,7 @@ describe('First login on Rancher', () => {
 describe('Epinio installation with default options', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
+    cy.visit('/');
     topLevelMenu.openIfClosed();
   });
 
@@ -33,7 +35,7 @@ describe('Epinio installation with default options', () => {
 describe('Menu testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
+    cy.visit('/');
     topLevelMenu.openIfClosed();
   });
 
@@ -52,7 +54,7 @@ describe('Menu testing', () => {
 describe('Applications testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
+    cy.visit('/');
     topLevelMenu.openIfClosed();
     epinio.accessEpinioMenu(Cypress.env('cluster'));
   });
@@ -77,7 +79,7 @@ describe('Applications testing', () => {
 describe('Configurations testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
+    cy.visit('/');
     topLevelMenu.openIfClosed();
     epinio.accessEpinioMenu(Cypress.env('cluster'));
   });
@@ -94,7 +96,7 @@ describe('Configurations testing', () => {
 describe('Namespaces testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
+    cy.visit('/');
     topLevelMenu.openIfClosed();
     epinio.accessEpinioMenu(Cypress.env('cluster'));
   });
@@ -111,7 +113,7 @@ describe('Namespaces testing', () => {
 describe('Epinio uninstallation testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
+    cy.visit('/');
     topLevelMenu.openIfClosed();
     cy.get('.clusters').contains(Cypress.env('cluster')).click()
   });

--- a/cypress/integration/scenarios/install_with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/install_with_s3_and_external_registry.spec.ts
@@ -1,3 +1,5 @@
+// This test is only used for testing Epinio in Rancher UI
+
 import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
 

--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -5,25 +5,30 @@ Cypress.config();
 const epinio = new Epinio();
 const topLevelMenu = new TopLevelMenu();
 
-describe('First login on Rancher', () => {
-  it('Log in and accept terms and conditions', () => {
+if (Cypress.env('ui') == "rancher") {
+  describe('First login on Rancher', () => {
+    it('Log in and accept terms and conditions', () => {
     cy.runFirstConnectionTest();
+    });
   });
-});
+}
 
 describe('Menu testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
+    cy.visit('/');
   });
-
+  
   it('Check Epinio menu', () => {
-    // Epinio's icon should appear in the side menu
-    epinio.epinioIcon().should('exist');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
 
-    // Click on the Epinio's logo as well as your Epinio instance
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+      // Epinio's icon should appear in the side menu
+      epinio.epinioIcon().should('exist');
+
+      // Click on the Epinio's logo as well as your Epinio instance 
+      epinio.accessEpinioMenu(Cypress.env('cluster')); 
+    }
 
     // Check Epinio's side menu
     epinio.checkEpinioNav();
@@ -33,9 +38,11 @@ describe('Menu testing', () => {
 describe('Applications testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {
@@ -62,9 +69,11 @@ describe('Applications testing', () => {
 describe('Configurations testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Create an application with a configuration, unbind the configuration and delete all', () => {
@@ -79,9 +88,11 @@ describe('Configurations testing', () => {
 describe('Namespaces testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Push and check an application into the created namespace', () => {

--- a/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
@@ -5,25 +5,30 @@ Cypress.config();
 const epinio = new Epinio();
 const topLevelMenu = new TopLevelMenu();
 
-describe('First login on Rancher', () => {
-  it('Log in and accept terms and conditions', () => {
+if (Cypress.env('ui') == "rancher") {
+  describe('First login on Rancher', () => {
+    it('Log in and accept terms and conditions', () => {
     cy.runFirstConnectionTest();
+    });
   });
-});
+}
 
 describe('Menu testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
+    cy.visit('/');
   });
   
   it('Check Epinio menu', () => {
-    // Epinio's icon should appear in the side menu
-    epinio.epinioIcon().should('exist');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
 
-    // Click on the Epinio's logo as well as your Epinio instance 
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+      // Epinio's icon should appear in the side menu
+      epinio.epinioIcon().should('exist');
+
+      // Click on the Epinio's logo as well as your Epinio instance 
+      epinio.accessEpinioMenu(Cypress.env('cluster')); 
+    }
 
     // Check Epinio's side menu
     epinio.checkEpinioNav();
@@ -33,9 +38,11 @@ describe('Menu testing', () => {
 describe('Applications testing', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Deploy an application to test external registry / s3', () => {

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -8,9 +8,11 @@ describe('Applications testing', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/integration/unit_tests/configurations.spec.ts
+++ b/cypress/integration/unit_tests/configurations.spec.ts
@@ -8,9 +8,11 @@ describe('Configuration testing', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Create an application with a configuration, unbind the configuration and delete all', () => {

--- a/cypress/integration/unit_tests/first_connexion.spec.ts
+++ b/cypress/integration/unit_tests/first_connexion.spec.ts
@@ -1,8 +1,8 @@
 import { Epinio } from '~/cypress/support/epinio';
- 
+
 Cypress.config();
 describe('First login on Rancher', () => {
-   const epinio = new Epinio();
+  const epinio = new Epinio();
 
   it('Log in and accept terms and conditions', () => {
     cy.visit('/auth/login');

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -8,16 +8,19 @@ describe('Menu testing', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
+    cy.visit('/');
   });
   
   it('Check Epinio menu', () => {
-    // Epinio's icon should appear in the side menu
-    epinio.epinioIcon().should('exist');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
 
-    // Click on the Epinio's logo as well as your Epinio instance 
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+      // Epinio's icon should appear in the side menu
+      epinio.epinioIcon().should('exist');
+
+      // Click on the Epinio's logo as well as your Epinio instance 
+      epinio.accessEpinioMenu(Cypress.env('cluster')); 
+    }
 
     // Check Epinio's side menu
     epinio.checkEpinioNav();

--- a/cypress/integration/unit_tests/namespaces.spec.ts
+++ b/cypress/integration/unit_tests/namespaces.spec.ts
@@ -8,9 +8,11 @@ describe('Namespaces testing', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/home');
-    topLevelMenu.openIfClosed();
-    epinio.accessEpinioMenu(Cypress.env('cluster'));
+    cy.visit('/');
+    if (Cypress.env('ui') == "rancher") {
+      topLevelMenu.openIfClosed();
+      epinio.accessEpinioMenu(Cypress.env('cluster'));
+    }
   });
 
   it('Push and check an application into the created namespace', () => {

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -22,6 +22,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.external_reg_password = process.env.EXT_REG_PASSWORD;
   config.env.s3_key_id = process.env.S3_KEY_ID;
   config.env.s3_key_secret = process.env.S3_KEY_SECRET;
+  config.env.ui = process.env.UI;
 
   return config;
 };

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -2,10 +2,13 @@ import 'cypress-file-upload';
 
 // Generic functions
 
-// Log into Rancher
-Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password'), cacheSession = Cypress.env('cache_session')) => {
+   // Log into Rancher
+Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password'), cacheSession = Cypress.env('cache_session'), ui = Cypress.env('ui')) => {
   const login = () => {
-    cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
+    let loginPath
+    ui == "rancher" ? loginPath="/v3-public/localProviders/local*" : loginPath="/pp/v1/epinio/rancher/v3-public/authProviders/local/login";
+    cy.intercept('POST', loginPath).as('loginReq');
+    
     cy.visit('/auth/login');
 
     cy.byLabel('Username')
@@ -18,7 +21,11 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 
     cy.get('button').click();
     cy.wait('@loginReq');
-    cy.contains("Getting Started", {timeout: 10000}).should('be.visible');
+    if (ui == "rancher") {
+      cy.contains("Getting Started", {timeout: 10000}).should('be.visible');
+    } else {
+      cy.contains('.m-0', 'Applications', {timeout: 20000});
+    }
   };
 
   if (cacheSession) {

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -35,7 +35,9 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.createApp({appName: appName, archiveName: archive, route: customRoute, sourceType: 'Archive'});
       cy.checkApp({appName: appName, route: customRoute});
       cy.showAppLog({appName: appName});
-      cy.showAppShell({appName: appName});
+      // App shell feature is not available in std UI yet
+      // https://github.com/epinio/ui/issues/84 
+      if (Cypress.env('ui') == "rancher") cy.showAppShell({appName: appName});
       break;
     case 'envVarsAndGitUrl':
       cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, addVar: 'ui', sourceType: 'Git URL'});

--- a/scripts/install_rancher.sh
+++ b/scripts/install_rancher.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Add stable Rancher Helm chart repo
-helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 
 # Add stable CertManager Helm chart repo
 helm repo add jetstack https://charts.jetstack.io
@@ -24,7 +24,7 @@ helm upgrade --install cert-manager jetstack/cert-manager \
 kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
 
 # Install Rancher
-helm upgrade --install rancher rancher-stable/rancher \
+helm upgrade --install rancher rancher-latest/rancher \
   --namespace cattle-system \
   --create-namespace \
   --set hostname=${MY_HOSTNAME} \


### PR DESCRIPTION
Fix #91 

This PR mainly brings the capability to execute our Cypress tests on the Epinio standalone UI.

- [x] I have to disable app shell check for the standalone UI

### CI ✅ 
Rancher UI Chrome: ✅  - https://github.com/epinio/epinio-end-to-end-tests/runs/6419108443?check_suite_focus=true
Rancher UI Firefox: ✅ - https://github.com/epinio/epinio-end-to-end-tests/actions/runs/2318031640
Epinio UI Chrome: ✅ - https://github.com/epinio/epinio-end-to-end-tests/runs/6418567388?check_suite_focus=true
Epinio UI Firefox: ✅ - https://github.com/epinio/epinio-end-to-end-tests/actions/runs/2317782432