### PR TITLE
Remove outdated scenarios from cfg files

### DIFF
--- a/cypress-with-epinio-cert.json
+++ b/cypress-with-epinio-cert.json
@@ -20,8 +20,6 @@
     "unit_tests/applications.spec.ts",
     "unit_tests/configurations.spec.ts",
     "unit_tests/namespaces.spec.ts",
-    "scenarios/install_with_default_options.spec.ts",
-    "scenarios/install_with_s3_and_external_registry.spec.ts",
     "scenarios/with_default_options.spec.ts",
     "scenarios/with_s3_and_external_registry.spec.ts",
     "unit_tests/uninstall.spec.ts"

--- a/cypress.json
+++ b/cypress.json
@@ -21,8 +21,6 @@
     "unit_tests/configurations.spec.ts",
     "unit_tests/namespaces.spec.ts",
     "unit_tests/uninstall.spec.ts",
-    "scenarios/install_with_default_options.spec.ts",
-    "scenarios/install_with_s3_and_external_registry.spec.ts",
     "scenarios/with_default_options.spec.ts",
     "scenarios/with_s3_and_external_registry.spec.ts"
   ]


### PR DESCRIPTION
Scenarios which have been deleted must be removed from the config files, otherwise you will get this error:
`[Error: ENAMETOOLONG: name too long, stat 'cypress/integration/cypress/integration/cypress`