### PR TITLE
adding cleansing prior each application test

### DIFF
--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -13,6 +13,11 @@ describe('Applications testing', () => {
       topLevelMenu.openIfClosed();
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
+    // Executes application cleansing of "testapp" 
+    // If the app does not exist it will not fail
+    cy.exec('epinio app delete testapp', { failOnNonZeroExit: false });
+    // Check that the application has effectively been destroyed
+    cy.contains('testapp', { timeout: 60000 }).should('not.exist');
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -13,11 +13,17 @@ describe('Applications testing', () => {
       topLevelMenu.openIfClosed();
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
-    // Executes application cleansing of "testapp" 
+    // Executes application cleansing of "testapp" and "configuration01"
     // If the app does not exist it will not fail
+    // Destroy application "testapp" and verify
     cy.exec('epinio app delete testapp', { failOnNonZeroExit: false });
-    // Check that the application has effectively been destroyed
+    cy.clickEpinioMenu('Applications');
     cy.contains('testapp', { timeout: 60000 }).should('not.exist');
+
+    // Destroy configuration "configuration01" and verify
+    cy.exec('epinio configuration delete configuration01', { failOnNonZeroExit: false });
+    cy.clickEpinioMenu('Configurations');
+    cy.contains('configuration01', { timeout: 60000 }).should('not.exist');
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {


### PR DESCRIPTION
Linked to issue [#161 ](https://github.com/epinio/epinio-end-to-end-tests/issues/161)
The purpose is to clean applications from `applications.spec.ts` at the beginning of each test.
I assumed we will use all the time "testapp" as based.
If we want generic, it needs to be further implemented