### PR TITLE
Increase tab timeout and enable app logs check

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -72,9 +72,8 @@ Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, s
   var getScope = ':nth-child(' + numIndex + ') > .col-badge-state-formatter > .status > .badge';
   if (sourceType == 'Container Image') {
     if (numIndex === 2) {
-      cy.get('.tab-label').should('contain', 'testapp - App Logs');
-      // App logs is disabled because of https://github.com/epinio/ui/issues/100
-      //cy.contains('Command line: \'httpd -D FOREGROUND\'', {timeout: timeout});
+      cy.get('.tab-label', {timeout: 100000}).should('contain', 'testapp - App Logs');
+      cy.contains('Command line: \'httpd -D FOREGROUND\'', {timeout: timeout});
       cy.get('.tab > .closer').click(); 
     }
   } else {
@@ -87,9 +86,8 @@ Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, s
         When step 3 (building is done), it automatically opens a new App logs tab
         and it hides the success badge of step 3...
         So we have to wait last step done before continuing */
-        cy.get('.tab-label').should('contain', 'testapp - App Logs');
-        // App logs is disabled because of https://github.com/epinio/ui/issues/100
-        //if (sourceType != 'Git URL') cy.contains('ready to handle connections', {timeout: timeout});
+        cy.get('.tab-label', {timeout: 100000}).should('contain', 'testapp - App Logs');
+        if (sourceType != 'Git URL') cy.contains('PHP 8.0.18 Development Server (http://0.0.0.0:8080) started', {timeout: timeout});
         cy.get('.tab > .closer').click();
       }      
   }


### PR DESCRIPTION
This PR increases the timeout of the app log tab.
It also add sthe app logs check back as https://github.com/epinio/ui/issues/100 fixed.

CI is green with the PR: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/2408959557