### PR TITLE
Add docker login action due to rate limiting

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -56,6 +56,12 @@ jobs:
         run: |
           echo "`pwd`/output/bin" >> $GITHUB_PATH
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Install K3s / Helm / Rancher
         id: installation
         env:

--- a/.github/workflows/master_std_ui_workflow.yml
+++ b/.github/workflows/master_std_ui_workflow.yml
@@ -67,6 +67,12 @@ jobs:
         run: |
           echo "`pwd`/output/bin" >> $GITHUB_PATH
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Install K3s / Helm / Rancher / Epinio
         id: installation
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 yarn.lock
+package-lock.json
 cypress/videos/*
+cypress/screenshots/*
+cypress/downloads/*


### PR DESCRIPTION
Sometimes, we reach the rate limit of docker hub and tests fail:

```
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  82s                default-scheduler  Successfully assigned epinio/kubed-58dd46c5c9-dsdm9 to gha1-runner-0
  Normal   Pulling    35s (x3 over 81s)  kubelet            Pulling image "appscode/kubed:v0.13.2"
  Warning  Failed     31s (x3 over 76s)  kubelet            Failed to pull image "appscode/kubed:v0.13.2": rpc error: code = Unknown desc = failed to pull and unpack image "docker.io/appscode/kubed:v0.13.2": failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/appscode/kubed/manifests/sha256:40ca90967d4a43d03c590a1c4b233cadf8fed747efcf34e64ff6a1871468a746: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
  Warning  Failed     31s (x3 over 76s)  kubelet            Error: ErrImagePull
  Normal   BackOff    7s (x4 over 76s)   kubelet            Back-off pulling image "appscode/kubed:v0.13.2"
  Warning  Failed     7s (x4 over 76s)   kubelet            Error: ImagePullBackOff
```