### PR TITLE
[Cypress] - Push docker secret in epinio

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -25,6 +25,10 @@ on:
         description: Set other docker options
         required: false
         type: string
+      ext_reg:
+        description: Enable external registry test
+        required: false
+        type: string
       runner:
         description: Runner on which to execute tests
         required: true
@@ -63,6 +67,7 @@ jobs:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
           K3S_VERSION: v1.22.7+k3s1
+          EXT_REG: ${{ inputs.ext_reg }}
           EXT_REG_USER: ${{ secrets.ext_reg_user }}
           EXT_REG_PASSWORD: ${{ secrets.ext_reg_password }}
           S3_KEY_ID: ${{ secrets.s3_key_id }}

--- a/.github/workflows/master_std_ui_workflow.yml
+++ b/.github/workflows/master_std_ui_workflow.yml
@@ -21,6 +21,10 @@ on:
         description: Set other docker options
         required: false
         type: string
+      ext_reg:
+        description: Enable external registry test
+        required: false
+        type: string
       runner:
         description: Runner on which to execute tests
         required: true
@@ -74,6 +78,7 @@ jobs:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
           K3S_VERSION: v1.22.7+k3s1
+          EXT_REG: ${{ inputs.ext_reg }}
           EXT_REG_USER: ${{ secrets.ext_reg_user }}
           EXT_REG_PASSWORD: ${{ secrets.ext_reg_password }}
           S3_KEY_ID: ${{ secrets.s3_key_id }}

--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -16,3 +16,6 @@ jobs:
       cypress_install_test: installation.spec.ts
       cypress_test: with_default_options.spec.ts
       runner: ui-e2e-0
+    secrets:
+      ext_reg_user: secrets.DOCKER_USER
+      ext_reg_password: secrets.DOCKER_PASSWORD

--- a/.github/workflows/scenario_1_chrome_std_ui.yml
+++ b/.github/workflows/scenario_1_chrome_std_ui.yml
@@ -15,3 +15,6 @@ jobs:
       cypress_image: cypress/browsers:node16.13.2-chrome97-ff96
       cypress_test: with_default_options.spec.ts
       runner: ui-e2e-1
+    secrets:
+      ext_reg_user: secrets.DOCKER_USER
+      ext_reg_password: secrets.DOCKER_PASSWORD

--- a/.github/workflows/scenario_2_firefox_rancher_ui.yml
+++ b/.github/workflows/scenario_2_firefox_rancher_ui.yml
@@ -19,6 +19,7 @@ jobs:
       # https://github.com/cypress-io/github-action#firefox
       docker_options: '--user 1000'
       runner: ui-e2e-2
+      ext_reg: '1'
     secrets:
       ext_reg_user: secrets.DOCKER_USER
       ext_reg_password: secrets.DOCKER_PASSWORD

--- a/.github/workflows/scenario_2_firefox_std_ui.yml
+++ b/.github/workflows/scenario_2_firefox_std_ui.yml
@@ -18,6 +18,7 @@ jobs:
       # https://github.com/cypress-io/github-action#firefox
       docker_options: '--user 1000'
       runner: ui-e2e-2
+      ext_reg: '1'
     secrets:
       ext_reg_user: secrets.DOCKER_USER
       ext_reg_password: secrets.DOCKER_PASSWORD

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,12 @@ uninstall-epinio: ## Uninstall Epinio with Helm
 get-ca: ## Configure Cypress to use the epinio-ca
 	@./scripts/get_ca.sh
 
-prepare-e2e-ci-rancher: install-k3s install-helm install-rancher get-ca ## Tests
+create-docker-secret: ## Create docker pull secret to avoid the docker hub rate limit
+	@./scripts/create_docker_secret.sh
 
-prepare-e2e-ci-standalone: install-k3s install-helm install-cert-manager install-epinio get-ca ## Tests
+prepare-e2e-ci-rancher: install-k3s install-helm install-rancher create-docker-secret get-ca ## Tests
+
+prepare-e2e-ci-standalone: install-k3s install-helm install-cert-manager create-docker-secret install-epinio get-ca ## Tests
 
 clean-k3s:
 	/usr/local/bin/k3s-uninstall.sh

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -79,7 +79,8 @@ Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, s
   } else {
       if (numIndex === 3) {
         cy.get('.tab-label').should('contain', 'testapp - Build');
-        cy.contains('buildpack: _ _ __ ___ _____ Done', {timeout: timeout});
+        cy.contains('===> EXPORTING', {timeout: timeout});
+        cy.contains('_ _ __ ___ _____ Done', {timeout: timeout});
         cy.get('.tab > .closer').click();
       
         /* Ugly thing here...
@@ -328,7 +329,7 @@ Cypress.Commands.add('rebuildApp', ({appName, namespace='workspace'}) => {
   cy.get('header').should('contain', appName).and('contain', 'Building');
   
   cy.get('.tab-label').should('contain', 'testapp - Build');
-  cy.contains('buildpack: Reusing layers from image', {timeout: 120000});
+  cy.contains('Reusing layers from image', {timeout: 120000});
   cy.get('.tab > .closer').click();
 
   cy.get('header', {timeout: 60000}).should('contain', appName).and('contain', 'Running');

--- a/scripts/create_docker_secret.sh
+++ b/scripts/create_docker_secret.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+# Create docker pull secret to avoid the docker hub rate limit
+kubectl create secret docker-registry regcred \
+  --docker-server https://index.docker.io/v1/ \
+  --docker-username $EXT_REG_USER \
+  --docker-password $EXT_REG_PASSWORD

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -10,7 +10,7 @@ make tools-install
 make build
 
 # Add options for External Registry if needed
-if [[ -n "${EXT_REG_USER}" && -n "${EXT_REG_PASSWORD}" ]]; then
+if [[ ${EXT_REG} == "1" ]]; then
   INSTALL_OPTIONS+="
    --set containerregistry.enabled=false \
    --set global.registryURL=registry.hub.docker.com \


### PR DESCRIPTION
Fix #167 
We have to push a secret to configure the docker credentials and avoid using an anonymous account.

CI:
Firefox / Rancher UI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/2415707285 :heavy_check_mark: 