### PR TITLE
Workaround to delete app and configuration before each

### DIFF
--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -44,16 +44,28 @@ describe('Applications testing', () => {
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
     // Executes application cleansing of "testapp" and "configuration01"
-    // If the app does not exist it will not fail
     // Destroy application "testapp" and verify
-    cy.exec('epinio app delete testapp', { failOnNonZeroExit: false });
+    // Could be a function later?
     cy.clickEpinioMenu('Applications');
-    cy.contains('testapp', { timeout: 60000 }).should('not.exist');
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('testapp')) {
+        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('testapp', {timeout: 60000}).should('not.exist');
+      };
+    });
 
     // Destroy configuration "configuration01" and verify
-    cy.exec('epinio configuration delete configuration01', { failOnNonZeroExit: false });
     cy.clickEpinioMenu('Configurations');
-    cy.contains('configuration01', { timeout: 60000 }).should('not.exist');
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('configuration01')) {
+        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('configurations01', {timeout: 60000}).should('not.exist');
+      };
+    });
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -13,17 +13,30 @@ describe('Applications testing', () => {
       topLevelMenu.openIfClosed();
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
+
     // Executes application cleansing of "testapp" and "configuration01"
-    // If the app does not exist it will not fail
     // Destroy application "testapp" and verify
-    cy.exec('epinio app delete testapp', { failOnNonZeroExit: false });
+    // Could be a function later?
     cy.clickEpinioMenu('Applications');
-    cy.contains('testapp', { timeout: 60000 }).should('not.exist');
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('testapp')) {
+        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('testapp', {timeout: 60000}).should('not.exist');
+      };
+    });
 
     // Destroy configuration "configuration01" and verify
-    cy.exec('epinio configuration delete configuration01', { failOnNonZeroExit: false });
     cy.clickEpinioMenu('Configurations');
-    cy.contains('configuration01', { timeout: 60000 }).should('not.exist');
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('configuration01')) {
+        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('configurations01', {timeout: 60000}).should('not.exist');
+      };
+    });
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -218,7 +218,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
   // Bind a configuration if needed
   if (configurationName) {
     cy.wait(500);  // We need to wait a little for the listbox to be updated
-    cy.get('.labeled-select').click();
+    cy.contains('.labeled-select', 'Configurations').click();
     cy.contains(configurationName, {timeout: 120000}).click();
   }
 
@@ -518,7 +518,7 @@ Cypress.Commands.add('bindConfiguration', ({appName, configurationName, namespac
   cy.wait(500);  // We need to wait a little for the listbox to be updated
   // 'multiple' and 'force' are needed here
   // TODO: try to find a better way for this
-  cy.get('.labeled-select').click({multiple: true, force: true});
+  cy.contains('.labeled-select', 'Configurations').click();
   cy.contains(configurationName, {timeout: 120000}).click();
 
   // And save


### PR DESCRIPTION
Basically, we do not have expected results with this PR #169, because the cy.exec call works only if Cypress is running in the same machine as k8s and that's not always the case.
This PR adds a quick workaround to fix it, we use the UI do delete the leftovers.
Maybe it could be improved by using an API call but I'm not sure it will be  faster because after all, the longest part is the deletion, so it will happen in both cases.

The second commit adds more precision to select the configuration tab, it's needed due to the introduction of the service feature.
![Configurations testing -- Create an application with a configuration, unbind the configuration and delete all (failed)](https://user-images.githubusercontent.com/6025636/171578783-0e510c3a-f0ed-463a-9ccb-dd61045d708b.png)

Result with this [branch](https://github.com/epinio/epinio-end-to-end-tests/runs/6698982003?check_suite_focus=true):
![image](https://user-images.githubusercontent.com/6025636/171579110-f88a1c23-59d1-4830-b623-e24528f0bcf9.png)
Even if the first test fails and leave an app with testapp name, the others tests ran correctly.