### PR TITLE
Remove deleteConfiguration prior manifest app upload

### DIFF
--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -65,8 +65,6 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.downloadManifest({ appName: appName });
       // Delete app prior uploading from manifest
       cy.deleteApp({ appName: appName });
-      // Delete the created configuration
-      cy.deleteConfiguration({ configurationName: configuration });
       // Create app from manifest solely and check results
       cy.createApp({archiveName: archive, sourceType: 'Archive', manifestName: manifest }); 
       cy.checkApp({appName: appName , checkConfiguration: true, route: customRoute, checkVar: true, instanceNum: 2});


### PR DESCRIPTION
Sibling of #151 

Removing the `deleteConfiguration` method from `downloadManifestAndPushApp` within `runApplicationsTest` in `tests.ts`
The information within the manifest is not for configuration creation, but binding, so the configuration previously established, must  exist for the test to pass.