### PR TITLE
Adapting Cypress to 9.0-0.0.3

### DIFF
--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -1,5 +1,6 @@
 import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
 
 Cypress.config();
 const epinio = new Epinio();
@@ -33,7 +34,20 @@ describe('Menu testing', () => {
     // Check Epinio's side menu
     epinio.checkEpinioNav();
   });
-});
+
+  it('Verify Welcome Screen without Namespaces', () => {
+    cy.clickEpinioMenu('Namespaces');
+    // Deletes all namespaces if detected
+    cy.get("body").then(($body) => {
+      if ($body.text().includes('Delete')) {
+        cy.deleteAllNamespaces()
+      }
+     }
+    )
+    cy.clickEpinioMenu('Applications');
+    cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+  }
+)});
 
 describe('Applications testing', () => {
   beforeEach(() => {
@@ -126,7 +140,7 @@ describe('Namespaces testing', () => {
     cy.runNamespacesTest('newNamespace');
   });
 
-  it('Try to push an application without any namespace', () => {
+  it.skip('Try to push an application without any namespace', () => {
     cy.runNamespacesTest('withoutNamespace');
   });
 });

--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -46,6 +46,7 @@ describe('Menu testing', () => {
     )
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+    cy.createNamespace('workspace')
   }
 )});
 

--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -46,7 +46,14 @@ describe('Menu testing', () => {
     )
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
-    cy.createNamespace('workspace')
+    // Verify creating namespace from Get Started button works
+    cy.get('a.btn.role-secondary').contains('Get started').click()
+    cy.clickButton('Create');
+    const defaultNamespace = 'workspace'
+    cy.typeValue({label: 'Name', value: defaultNamespace});
+    cy.clickButton('Create');
+    // Check that the namespace has effectively been created
+    cy.contains(defaultNamespace).should('be.visible');
   }
 )});
 
@@ -139,9 +146,5 @@ describe('Namespaces testing', () => {
 
   it('Push and check an application into the created namespace', () => {
     cy.runNamespacesTest('newNamespace');
-  });
-
-  it.skip('Try to push an application without any namespace', () => {
-    cy.runNamespacesTest('withoutNamespace');
   });
 });

--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -45,7 +45,7 @@ describe('Menu testing', () => {
      }
     )
     cy.clickEpinioMenu('Applications');
-    cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+    cy.get('h1').contains('Welcome to Epinio').should('be.visible')
     // Verify creating namespace from Get Started button works
     cy.get('a.btn.role-secondary').contains('Get started').click()
     cy.clickButton('Create');

--- a/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
@@ -46,7 +46,14 @@ describe('Menu testing', () => {
     )
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
-    cy.createNamespace('workspace')
+    // Verify creating namespace from Get Started button works
+    cy.get('a.btn.role-secondary').contains('Get started').click()
+    cy.clickButton('Create');
+    const defaultNamespace = 'workspace'
+    cy.typeValue({label: 'Name', value: defaultNamespace});
+    cy.clickButton('Create');
+    // Check that the namespace has effectively been created
+    cy.contains(defaultNamespace).should('be.visible');
   }
 )});
 

--- a/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
@@ -1,5 +1,6 @@
 import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
 
 Cypress.config();
 const epinio = new Epinio();
@@ -33,7 +34,20 @@ describe('Menu testing', () => {
     // Check Epinio's side menu
     epinio.checkEpinioNav();
   });
-});
+
+  it('Verify Welcome Screen without Namespaces', () => {
+    cy.clickEpinioMenu('Namespaces');
+    // Deletes all namespaces if detected
+    cy.get("body").then(($body) => {
+      if ($body.text().includes('Delete')) {
+        cy.deleteAllNamespaces()
+      }
+     }
+    )
+    cy.clickEpinioMenu('Applications');
+    cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+  }
+)});
 
 describe('Applications testing', () => {
   beforeEach(() => {

--- a/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
@@ -46,6 +46,7 @@ describe('Menu testing', () => {
     )
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+    cy.createNamespace('workspace')
   }
 )});
 

--- a/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
@@ -45,7 +45,7 @@ describe('Menu testing', () => {
      }
     )
     cy.clickEpinioMenu('Applications');
-    cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+    cy.get('h1').contains('Welcome to Epinio').should('be.visible')
     // Verify creating namespace from Get Started button works
     cy.get('a.btn.role-secondary').contains('Get started').click()
     cy.clickButton('Create');

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -38,6 +38,13 @@ describe('Menu testing', () => {
     )
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
-    cy.createNamespace('workspace')
+    // Verify creating namespace from Get Started button works
+    cy.get('a.btn.role-secondary').contains('Get started').click()
+    cy.clickButton('Create');
+    const defaultNamespace = 'workspace'
+    cy.typeValue({label: 'Name', value: defaultNamespace});
+    cy.clickButton('Create');
+    // Check that the namespace has effectively been created
+    cy.contains(defaultNamespace).should('be.visible');
   }
 )});

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -1,5 +1,6 @@
 import { Epinio } from '~/cypress/support/epinio';
 import { TopLevelMenu } from '~/cypress/support/toplevelmenu';
+import '~/cypress/support/functions';
 
 Cypress.config();
 describe('Menu testing', () => {
@@ -25,4 +26,17 @@ describe('Menu testing', () => {
     // Check Epinio's side menu
     epinio.checkEpinioNav();
   });
-});
+
+  it('Verify Welcome Screen without Namespaces', () => {
+    cy.clickEpinioMenu('Namespaces');
+    // Deletes all namespaces if detected
+    cy.get("body").then(($body) => {
+      if ($body.text().includes('Delete')) {
+        cy.deleteAllNamespaces()
+      }
+     }
+    )
+    cy.clickEpinioMenu('Applications');
+    cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+  }
+)});

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -37,7 +37,7 @@ describe('Menu testing', () => {
      }
     )
     cy.clickEpinioMenu('Applications');
-    cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+    cy.get('h1').contains('Welcome to Epinio').should('be.visible')
     // Verify creating namespace from Get Started button works
     cy.get('a.btn.role-secondary').contains('Get started').click()
     cy.clickButton('Create');

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -38,5 +38,6 @@ describe('Menu testing', () => {
     )
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio', { timeout: 4000 }).should('be.visible')
+    cy.createNamespace('workspace')
   }
 )});

--- a/cypress/integration/unit_tests/namespaces.spec.ts
+++ b/cypress/integration/unit_tests/namespaces.spec.ts
@@ -18,10 +18,4 @@ describe('Namespaces testing', () => {
   it('Push and check an application into the created namespace', () => {
     cy.runNamespacesTest('newNamespace');
   });
-
-  // Tests removed since udgrade to v.9.0-0.0.3 
-  // Since that version namespace creation is mandatory app creation.
-  it.skip('Try to push an application without any namespace', () => {
-    cy.runNamespacesTest('withoutNamespace');
-  });
 });

--- a/cypress/integration/unit_tests/namespaces.spec.ts
+++ b/cypress/integration/unit_tests/namespaces.spec.ts
@@ -19,7 +19,9 @@ describe('Namespaces testing', () => {
     cy.runNamespacesTest('newNamespace');
   });
 
-  it('Try to push an application without any namespace', () => {
+  // Tests removed since udgrade to v.9.0-0.0.3 
+  // Since that version namespace creation is mandatory app creation.
+  it.skip('Try to push an application without any namespace', () => {
     cy.runNamespacesTest('withoutNamespace');
   });
 });

--- a/cypress/support/epinio.ts
+++ b/cypress/support/epinio.ts
@@ -4,12 +4,22 @@ export class Epinio {
   } 
 
   checkEpinioNav() {
-    return cy.get('.list-unstyled > li').should(($lis) => {
-      expect($lis).to.have.length(3);
-      expect($lis.eq(0)).to.contain('Applications');
-      expect($lis.eq(1)).to.contain('Configurations');
-      expect($lis.eq(2)).to.contain('Namespaces');
-    })
+    // Open Services & Advanced accordions
+    cy.get('div.header > i').eq(0).click()
+    cy.get('div.header').contains('Services').should('be.visible')
+    cy.get('div.header').contains('Advanced').should('be.visible')
+    cy.get('div.header > i').eq(1).click()
+   
+    // Check all listed options once accordions are opened
+    cy.get('li.child.nav-type').should(($lis) => {
+    expect($lis).to.have.length(6);
+    expect($lis.eq(0)).to.contain('Applications');
+    expect($lis.eq(1)).to.contain('Namespaces');
+    expect($lis.eq(2)).to.contain('Instances');
+    expect($lis.eq(3)).to.contain('Catalog');
+    expect($lis.eq(4)).to.contain('Configurations');
+    expect($lis.eq(5)).to.contain('Application Templates');
+    })      
   }
 
   accessEpinioMenu(cluster: string) {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -597,7 +597,9 @@ Cypress.Commands.add('editConfiguration', ({configurationName, namespace='worksp
   cy.get('.no-resize').type('_add');
   cy.clickButton('Save'); 
   cy.get('header').should('contain', 'Configurations:').and('contain', configurationName).and('not.contain', 'Saving');
-
+  // For some reason if at this points changes screen and we attempt to delete the app,
+  // it will crash. A bit of extra time,helps to prevent this.
+  cy.wait(6000)
   // For now, that's not possible to check that the configuration has effectively been changed
   // because we can't scrap the value in the html page, maybe because the field is grey.
   // Attach to app might be a solution for checking it but the feature is not yet released.

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -24,7 +24,10 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     if (ui == "rancher") {
       cy.contains("Getting Started", {timeout: 10000}).should('be.visible');
     } else {
-      cy.contains('.m-0', 'Applications', {timeout: 20000});
+      cy.get('body').then($body => {
+       if ($body.text().includes('Namespace')) {cy.contains('.m-0', 'Applications', {timeout: 20000});}
+       else {cy.get('h1').contains('Welcome to Epinio', {timeout: 20000})}
+      }) 
     }
   };
 
@@ -47,6 +50,7 @@ Cypress.Commands.add('clickButton', (label) => {
 
 // Ensure that we are in the desired menu
 Cypress.Commands.add('clickEpinioMenu', (label) => {
+  cy.get('.header').contains('Advanced').click();
   cy.get('.label').contains(label).click();
   cy.location('pathname').should('include', '/' + label.toLocaleLowerCase());
   cy.get('.m-0').should('contain', label);
@@ -272,7 +276,7 @@ Cypress.Commands.add('checkApp', ({appName, namespace='workspace', route, checkV
   // Check binded configurations
   var configurationNum = 0;
   if (checkConfiguration === true) configurationNum = 1;
-  cy.contains(configurationNum + ' Configs', {timeout: 24000}).should('be.visible');
+  cy.contains(configurationNum + ' Configurations', {timeout: 24000}).should('be.visible');
 
   // Check the application route
   var appRoute = 'https://' + appName + '.' + Cypress.env('system_domain');

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -16,7 +16,7 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
-      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string): Chainable<Element>;
+      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;
@@ -26,6 +26,7 @@ declare global {
       downloadManifest(appName: string): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
+      deleteAllNamespaces():Chainable<Element>;
       createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       editConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -23,6 +23,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
   const archive = 'sample-app.tar.gz';
   const customRoute = 'custom-route-' + appName + '.' + Cypress.env('system_domain');
   const paketobuild = 'paketobuildpacks/builder:tiny';
+  const applicationChart = ' standard (Epinio standard deployment)';
   const gitUrl = 'https://github.com/epinio/example-go';
   const configuration = 'configuration01';
   const manifest = 'manifest.json';
@@ -55,7 +56,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       //cy.checkApp({appName: appName});
       break;
     case 'allTests':
-      cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, instanceNum: 5, addVar: 'ui', route: customRoute, sourceType: 'Git URL'});
+      cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, customApplicationChart:applicationChart, instanceNum: 5, addVar: 'ui', route: customRoute, sourceType: 'Git URL'});
       cy.checkApp({appName: appName, checkVar: true, route: customRoute});
       break;
     case 'downloadManifestAndPushApp':

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -65,8 +65,6 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.downloadManifest({ appName: appName });
       // Delete app prior uploading from manifest
       cy.deleteApp({ appName: appName });
-      // Delete the created configuration
-      cy.deleteConfiguration({ configurationName: configuration });
       // Create app from manifest solely and check results
       cy.createApp({archiveName: archive, sourceType: 'Archive', manifestName: manifest }); 
       cy.checkApp({appName: appName , checkConfiguration: true, route: customRoute, checkVar: true, instanceNum: 2});

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -146,16 +146,5 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       // Delete the namespace
       cy.deleteNamespace({namespace: namespace, appName: appName});
       break;
-    case 'withoutNamespace':
-      // Delete default namespace
-      cy.wait(5000); // Workaround for https://github.com/rancher/dashboard/issues/5240
-      cy.deleteNamespace({namespace: defaultNamespace});
-
-      // Try to create the application
-      cy.createApp({appName: appName, archiveName: archive, sourceType: 'Archive', shouldBeDisabled: true});
-
-      // Re-create default namespace
-      cy.createNamespace(defaultNamespace);
-      break;
   }
 });

--- a/cypress/support/toplevelmenu.ts
+++ b/cypress/support/toplevelmenu.ts
@@ -1,6 +1,6 @@
 export class TopLevelMenu {
   toggle() {
-    cy.get('.menu-icon', {timeout: 12000}).click();
+    cy.get('img.side-menu-logo', {timeout: 12000}).click();
   }
 
   openIfClosed() {


### PR DESCRIPTION
Adapting cypress tests to new changes after 9.0-0.0.3 updates.
Related issue #174 

Updates done:

- Removed outdated tests: it('Try to push an application without any namespace')  
- Create namespace from get started button
- Check new options on left menu (advanced settings, services, etc)
- Added functionalty to delete all workspaces.
- Added checkup of new epinio page on applications when no namespaces exist
- Added check on Application Charts
- Locators adaptation


