### PR TITLE
Move Cypress tests on new STD UI CI

### DIFF
--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -1,12 +1,42 @@
 # This workflow is a reusable one called by other workflows
-name: Latest Standalone UI installation
-
+name: Latest STD UI workflow (template)
 on:
-  workflow_dispatch:
+  workflow_call:
+  # Variables to set when calling this reusable workflow
+    inputs:
+      browser:
+        description: Web browser to test
+        required: true
+        type: string
+      cypress_docker:
+        description: Cypress docker image to use
+        required: true
+        type: string
+      cypress_spec:
+        description: Which Cypress test to execute
+        required: true
+        type: string
+      docker_options:
+        description: Set other docker options
+        required: false
+        type: string
+      ext_reg:
+        description: Enable external registry test
+        required: false
+        type: string
+    secrets:
+      ext_reg_user:
+        required: false
+      ext_reg_password:
+        required: false
+      s3_key_id:
+        required: false
+      s3_key_secret:
+        required: false
 
 jobs:
   E2E-Cypress:
-    runs-on: ui-e2e-3
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -82,17 +112,20 @@ jobs:
       
       - name: Start Cypress tests
         env:
-          BROWSER: chrome
-          CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
+          BROWSER: ${{ inputs.browser }}
           CYPRESS_CFG: cypress-with-epinio-cert.json
-          CYPRESS_DOCKER: cypress/included:9.7.0 
+          CYPRESS_DOCKER: ${{ inputs.cypress_docker }}
+          DOCKER_OPTIONS: ${{ inputs.docker_options }}
           EXT_REG_USER: ${{ secrets.DOCKER_USER }}
           EXT_REG_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           RANCHER_PASSWORD: password
           RANCHER_URL: https://host.docker.internal:8005
           RANCHER_USER: admin
-          SPEC: cypress/integration/scenarios/with_default_options.spec.ts
+          SPEC: ${{ inputs.cypress_spec }}
+          SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
+
         run: |
+          # Ugly sleep to wait the deployment of the dev dashboard in background...
           sleep 240
           ETH_DEV=$(ip route | awk '/default via / { print $5 }')
           MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)

--- a/.github/workflows/scenario_1_chrome_std_ui.yml
+++ b/.github/workflows/scenario_1_chrome_std_ui.yml
@@ -1,5 +1,5 @@
 # This workflow calls the master UI workflow with custom variables
-name: Standalone-UI-1-Chrome
+name: STD-UI-default-Chrome
 
 on:
   workflow_dispatch:
@@ -9,12 +9,11 @@ on:
 
 jobs:
   std-chrome:
-    uses: ./.github/workflows/master_std_ui_workflow.yml
+    uses: ./.github/workflows/master_std_ui.yml
     with:
       browser: chrome
-      cypress_image: cypress/browsers:node16.13.2-chrome97-ff96
-      cypress_test: with_default_options.spec.ts
-      runner: ui-e2e-1
+      cypress_docker: cypress/included:9.7.0 
+      cypress_spec: cypress/integration/scenarios/with_default_options.spec.ts
     secrets:
       ext_reg_user: secrets.DOCKER_USER
       ext_reg_password: secrets.DOCKER_PASSWORD

--- a/.github/workflows/scenario_2_firefox_std_ui.yml
+++ b/.github/workflows/scenario_2_firefox_std_ui.yml
@@ -1,5 +1,5 @@
 # This workflow calls the master UI workflow with custom variables
-name: Standalone-UI-2-Firefox
+name: STD-UI-s3-ext_reg-Firefox
 
 on:
   workflow_dispatch:
@@ -9,15 +9,14 @@ on:
 
 jobs:
   std-firefox:
-    uses: ./.github/workflows/master_std_ui_workflow.yml
+    uses: ./.github/workflows/master_std_ui.yml
     with:
       browser: firefox
-      cypress_image: cypress/browsers:node16.13.2-chrome97-ff96
-      cypress_test: with_s3_and_external_registry.spec.ts
+      cypress_image: cypress/included:9.7.0
+      cypress_test: cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
       # Due to security reason, Firefox can't be started as root
       # https://github.com/cypress-io/github-action#firefox
       docker_options: '--user 1000'
-      runner: ui-e2e-2
       ext_reg: '1'
     secrets:
       ext_reg_user: secrets.DOCKER_USER

--- a/scripts/start_cypress_tests.sh
+++ b/scripts/start_cypress_tests.sh
@@ -12,6 +12,7 @@ docker run -v $PWD:/e2e -w /e2e                  \
     -e SYSTEM_DOMAIN=$EPINIO_SYSTEM_DOMAIN       \
     -e RANCHER_URL=$RANCHER_URL                  \
     --add-host host.docker.internal:host-gateway \
+    $DOCKER_OPTIONS                              \
     $CYPRESS_DOCKER                              \
     -C /e2e/$CYPRESS_CFG                         \
     -b $BROWSER                                  \


### PR DESCRIPTION
Now that we have a [workflow](https://github.com/epinio/epinio-end-to-end-tests/pull/181) to deploy latest standalone UI.
We can modify other workflow files to call the new master file (master_std_ui.yml), yes we are using [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) here.
Fix #179 