### PR TITLE
Use data-testid to select topLevelMenu

### DIFF
--- a/cypress/support/toplevelmenu.ts
+++ b/cypress/support/toplevelmenu.ts
@@ -1,6 +1,6 @@
 export class TopLevelMenu {
   toggle() {
-    cy.get('img.side-menu-logo', {timeout: 12000}).click();
+    cy.get('[data-testid="top-level-menu"]', {timeout: 12000}).click();
   }
 
   openIfClosed() {


### PR DESCRIPTION
Use new selector `data-testid`  and fix this issue:
![image](https://user-images.githubusercontent.com/6025636/174677877-d33cf5cd-31f0-479f-936d-be027b15992e.png)
