### PR TITLE
Build and publish latest UI as draft binary

### DIFF
--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -1,0 +1,86 @@
+name: Build Latest-STD-UI
+
+on:
+  workflow_dispatch:
+  
+  schedule:
+    - cron: '0 21 * * *'
+
+env:
+  OUTPUT_DIR: dist
+  RELEASE_DIR: latest
+  ARTIFACT_NAME: latest-rancher-dashboard-epinio-standalone-embed
+
+jobs:
+  build_and_publish:
+
+    # BUILD LATEST RANCHER DASHBOARD
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout dashboard repo
+      uses: actions/checkout@v2
+      with:
+        repository: rancher/dashboard
+        ref: epinio-dev
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12.x'
+
+    - name: Install & Build
+      run:
+        RANCHER_ENV=epinio ./.github/workflows/scripts/build-dashboard.sh
+
+    - name: Upload Build
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ env.RELEASE_DIR}}/${{ env.ARTIFACT_NAME }}*
+        name: ${{ env.ARTIFACT_NAME }}
+        if-no-files-found: error
+
+    # BUILD LATEST UI-BACKEND
+    - name: Checkout dashboard repo
+      uses: actions/checkout@v2
+      with:
+        repository: epinio/ui-backend
+
+    # A tag is mandatory but it will not be pushed in the repo
+    # because we do not release
+    - name: Create fake tag
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git tag -a v99.0.0 -m "Fake tag for QA" --force
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Download the dashboard
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ui
+
+    - name: Download dashboard
+      run: |
+        tar xfz *.tar.gz -C ui
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --skip-announce --skip-validate --skip-sign --config .goreleaser-dashboard-qa.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser-dashboard-qa.yml
+++ b/.goreleaser-dashboard-qa.yml
@@ -1,0 +1,87 @@
+---
+project_name: epinio-ui-qa
+
+archives:
+  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      amd64: x86_64
+    format: binary
+    format_overrides:
+      - goos: windows
+        format: zip
+
+before:
+  hooks:
+    - sh -c "cd src/jetstream && go mod download"
+
+builds:
+  - id: epinio-ui
+    dir: src/jetstream
+    binary: epinio-ui
+    ldflags:
+      - -w -s
+      - -X "main.appVersion={{ .Tag }}"
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+changelog:
+  skip: true
+
+dockers:
+  -
+    use: buildx
+    # ID of the image, needed if you want to filter by it later on (e.g. on custom publishers).
+    id: epinio-ui
+
+    # GOOS of the built binaries/packages that should be used.
+    goos: linux
+
+    # GOARCH of the built binaries/packages that should be used.
+    goarch: amd64
+
+    # IDs to filter the binaries/packages.
+    ids:
+    - epinio-ui
+
+    # Templates of the Docker image names.
+    image_templates:
+    - "juadk/epinio-ui-qa:{{ .Tag }}-amd64"
+
+    # Path to the Dockerfile (from the project root).
+    dockerfile: Dockerfile
+
+    # Template of the docker build flags.
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=epinio.io.ui.source={{.Env.UI_BUNDLE_URL}}"
+    - "--label=org.opencontainers.image.source=https://github.com/epinio/epinio-end-to-end-tests/ui-backend"
+    - "--build-arg=DIST_BINARY=epinio-ui"
+    - "--platform=linux/amd64"
+
+    # If your Dockerfile copies files other than binaries and packages,
+    # you should list them here as well.
+    # Note that GoReleaser will create the same structure inside a temporary
+    # folder, so if you add `foo/bar.json` here, on your Dockerfile you can
+    # `COPY foo/bar.json /whatever.json`.
+    # Also note that the paths here are relative to the folder in which
+    # GoReleaser is being run (usually the repository root folder).
+    # This field does not support wildcards, you can add an entire folder here
+    # and use wildcards when you `COPY`/`ADD` in your Dockerfile.
+    extra_files:
+    - ui/
+
+release:
+  disable: true
+
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  -
+    name_template: "juadk/epinio-ui-qa:latest"
+    image_templates:
+    - "juadk/epinio-ui-qa:{{ .Tag }}-amd64"


### PR DESCRIPTION
In every CI tests, we build latest dashboard and it's time consuming and not efficient at all.
The good way is to build a docker image with latest epinio-ui and publish it in a sandbox repo.
Then, each CI tests can pull it and run faster.

This PR only adds two files, it won't break anything and I have to merge it to try the workflow...
If something is wrong, I will be able to fix it and test the CI from my branch.