### PR TITLE
UI test for Github source type

### DIFF
--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -67,4 +67,8 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('serviceMysqlBindWordpressPushApp');
   });
 
+  it('Push application with Github Source type and env vars and check it',  () => {
+    cy.runApplicationsTest('gitHubAndEnvVar');
+  });
+
 });

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -100,7 +100,7 @@ Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, s
         and it hides the success badge of step 3...
         So we have to wait last step done before continuing */
         cy.get('.tab-label', {timeout: 100000}).should('contain', 'testapp - App Logs');
-        if (sourceType != 'Git URL') cy.contains('Development Server (http://0.0.0.0:8080) started', {timeout: timeout});
+        if (sourceType != 'Git URL' && sourceType != 'GitHub') cy.contains('Development Server (http://0.0.0.0:8080) started', {timeout: timeout});
         cy.get('.tab > .closer').click();
       }      
   }
@@ -181,7 +181,22 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         break;
       case 'Archive':
         cy.get('.archive input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});
+        // Locator changes on latest dashboard dev version. 
+        // Replace to this once upgraded.
+        // cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});       
         break; 
+      case 'GitHub':
+        cy.typeValue({label: 'Username / Organization', value: 'epinio'}); 
+        // Function 'typeValue' not working here
+        // Selecting Repository
+        cy.get('.labeled-select.edit.hoverable').contains('label', 'Repository').click();
+        cy.contains('example-go').click();
+        // Selecting Branch
+        cy.get('.labeled-select.edit.hoverable').contains('label', 'Branch').click();
+        cy.contains('main').click();
+        // Selecting last commit
+        cy.get('span.radio-custom').last().click();
+        break;
     };
   };
 
@@ -251,6 +266,12 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
     cy.get('.no-resize').eq(2).should('have.value', 'wordpress ');
     cy.get('.key > input').eq(3).should('have.value', 'CONFIG_NAME');
     cy.get('.no-resize').eq(3).should('have.value', 'x5dc8835923fe6cac2053d8aa18b1-mysql');
+  }
+
+  if (addVar === 'go_example') {
+    cy.get('.key-value > .footer > .add').click();
+    cy.typeKeyValue({key: '.kv-item.key', value: 'BP_KEEP_FILES'});
+    cy.typeKeyValue({key: '.kv-item.value', value: 'static/*'});
   }
   
   // Set the desired number of instances

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -75,6 +75,10 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.createService({ serviceName: customService, catalogType: customCatalog })
       cy.createApp( {appName: appName, archiveName: gitUrlWordpress, sourceType: 'Git URL', addVar: 'wordpress_env_file', serviceName: customService, catalogType: customCatalog });
       cy.checkApp({ appName: appName, dontCheckRouteAccess: true, serviceName: customService, checkCreatedApp: 'wordpress'});  
+    case 'gitHubAndEnvVar':
+      cy.createApp({appName: appName, addVar: 'go_example', sourceType: 'GitHub'});
+      cy.checkApp({appName: appName, checkVar: true});
+      break;
   }
 
   // Delete the tested application


### PR DESCRIPTION
Test implementation of https://github.com/epinio/epinio-end-to-end-tests/issues/215

**Test covers:**
- Deploy example-go (https://github.com/epinio/example-go) using new feature SourceType=GitHub
- Ensure these fields are selected: username=epinio; repository=example-go; branch=main; commit=latest. It also uses an env var needed  for this application.
- Checks application name and env var.

**Results (locally run**):
![github-sourcetype](https://user-images.githubusercontent.com/37271841/186835412-6823e353-0986-457c-a455-44944c6bb4ac.png)




Note: at the moment of this test it does not cover checking visually the application using `checkCreatedApp` method. The reason is the local run uses an URL (https://192.168.1.44:8005/)  which is different from the one present in Routes (https://testapp-nnnn.172.19.0.3.omg.howdoi.website) and would force some rework on the code just for testing purposes. This should be necessary once the latest UI changes are bumped; hence, I am omitting this extra validation for the moment, but will add it on the near future once bump is done.