### PR TITLE
Fix epinio namespace creation in rancher

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -724,7 +724,10 @@ Cypress.Commands.add('epinioInstall', ({s3, extRegistry}) => {
 
   // Namespace where installation will happen
   cy.typeValue({label: 'Name', value: 'epinio-install'});
-  cy.contains('default').type('epinio{enter}');
+  // Typing just a new namespace name is not enough, select 'Create a New Namespace' first
+  cy.get('div.vs__selected-options').eq(0).click();
+  cy.get('li.vs__dropdown-option').contains('Create a New Namespace').click({force: true});
+  cy.get(':nth-child(1) > .labeled-input').type('epinio');
   cy.clickButton('Next');
   
   // Configure custom domain


### PR DESCRIPTION
This fixes an issue when `epinioInstall` function was unable to create new `epinio` namespace when installating `epinio` from recent Rancher v2.6.8 by using upstream epinio helm chart. Before that it was installed into `default` namespace instead.

~I'm sure the proposed solution is sub-optimal but it works. Ideally we should select the `Create a New Namespace` entry from namespace dropdown by pre-loading the dd entires and selecting (and validating) the proper one but so far I have no idea how to achieve that.~

Edit 092722: used the solution provided by @juadk, thanks