### PR TITLE
Disabling qa latest image pull until fixed

### DIFF
--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -110,10 +110,11 @@ jobs:
 
       # Disabling this until it is fixed
       # Related issue: https://github.com/epinio/epinio-end-to-end-tests/issues/223
-      # - name: Patch epinio-ui with latest QA image
-      #   env:
-      #     KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-      #   run: |
+      - name: Patch epinio-ui with latest QA image
+        env:
+          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+        run: |
+          echo "::warning::Temporary Disabled"
       #     make patch-epinio-ui
       
       - name: Start Cypress tests

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -108,11 +108,13 @@ jobs:
           echo '::set-output name=MY_IP::'${MY_IP}
           make prepare-e2e-ci-standalone
 
-      - name: Patch epinio-ui with latest QA image
-        env:
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        run: |
-          make patch-epinio-ui
+      # Disabling this until it is fixed
+      # Related issue: https://github.com/epinio/epinio-end-to-end-tests/issues/223
+      # - name: Patch epinio-ui with latest QA image
+      #   env:
+      #     KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      #   run: |
+      #     make patch-epinio-ui
       
       - name: Start Cypress tests
         env:


### PR DESCRIPTION
Related issue: https://github.com/epinio/epinio-end-to-end-tests/issues/223, https://github.com/epinio/epinio-end-to-end-tests/issues/218

Disabling temporarily patching of latest qa image epinio-ui-qa:latest since it seemed not working over a month. 

It seemed that latest changes on v.1.2.0 were not reflected on version from next day after release:
https://github.com/epinio/epinio-end-to-end-tests/runs/8263707860?check_suite_focus=true

![image](https://user-images.githubusercontent.com/37271841/189370853-b535dc4c-2f81-4833-bc0f-aedf57e36842.png)

After disabling it we capture the latest 1.2.0 version. Here it is a link to CI done while testing the full flow:
https://github.com/epinio/epinio-end-to-end-tests/runs/8270729048?check_suite_focus=true
![image](https://user-images.githubusercontent.com/37271841/189371217-49fe87e5-7bff-403f-a325-068a29e4dd6f.png)


