### PR TITLE
Bump node version for epinioUI build

### DIFF
--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: actions/setup-node@v2
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install & Build
       run: |


### PR DESCRIPTION
Fixes #223

Bump of node is needed, I used the same value as used in official release job https://github.com/rancher/dashboard/commit/fca2e4d07e281de778be12bb0c16f279f6362916

The image was updated on dockerhub already after running the job in my PR branch, see https://hub.docker.com/r/epinioteam/epinio-ui-qa/tags