### PR TITLE
Revert "Disabling qa latest image pull until fixed (#224)"

### DIFF
--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -108,14 +108,11 @@ jobs:
           echo '::set-output name=MY_IP::'${MY_IP}
           make prepare-e2e-ci-standalone
 
-      # Disabling this until it is fixed
-      # Related issue: https://github.com/epinio/epinio-end-to-end-tests/issues/223
       - name: Patch epinio-ui with latest QA image
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
-          echo "::warning::Temporary Disabled"
-      #     make patch-epinio-ui
+          make patch-epinio-ui
       
       - name: Start Cypress tests
         env:


### PR DESCRIPTION
Fixes https://github.com/epinio/epinio-end-to-end-tests/issues/223

as we fixed building and publishing of epinioUI testing image by https://github.com/epinio/epinio-end-to-end-tests/pull/225 we may re-enable again.