### PR TITLE
Cypress/218 fixing cypress

### DIFF
--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -112,8 +112,7 @@ jobs:
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
-          echo "::warning::Temporary Disabled"
-          # make patch-epinio-ui
+          make patch-epinio-ui
       
       - name: Start Cypress tests
         env:

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -108,11 +108,11 @@ jobs:
           echo '::set-output name=MY_IP::'${MY_IP}
           make prepare-e2e-ci-standalone
 
-      - name: Patch epinio-ui with latest QA image
-        env:
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-        run: |
-          make patch-epinio-ui
+      # - name: Patch epinio-ui with latest QA image
+      #   env:
+      #     KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      #   run: |
+      #     make patch-epinio-ui
       
       - name: Start Cypress tests
         env:

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -112,7 +112,8 @@ jobs:
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
-          make patch-epinio-ui
+          echo "::warning::Temporary Disabled"
+          # make patch-epinio-ui
       
       - name: Start Cypress tests
         env:

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -20,7 +20,7 @@ describe('Applications testing', () => {
     cy.clickEpinioMenu('Applications');
     cy.get('body').then(($body) => {
       if ($body.text().includes('testapp')) {
-        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.get('[width="30"] > .checkbox-outer-container.check').click();
         cy.clickButton('Delete');
         cy.confirmDelete();
         cy.contains('testapp', {timeout: 60000}).should('not.exist');
@@ -31,7 +31,7 @@ describe('Applications testing', () => {
     cy.clickEpinioMenu('Configurations');
     cy.get('body').then(($body) => {
       if ($body.text().includes('configuration01')) {
-        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.get('[width="30"] > .checkbox-outer-container.check').click();
         cy.clickButton('Delete');
         cy.confirmDelete();
         cy.contains('configurations01', {timeout: 60000}).should('not.exist');

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -67,7 +67,7 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('serviceMysqlBindWordpressPushApp');
   });
 
-  it.skip('Push application with Github Source type and env vars and check it',  () => {
+  it('Push application with Github Source type and env vars and check it',  () => {
     cy.runApplicationsTest('gitHubAndEnvVar');
   });
 

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -67,7 +67,7 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('serviceMysqlBindWordpressPushApp');
   });
 
-  it('Push application with Github Source type and env vars and check it',  () => {
+  it.skip('Push application with Github Source type and env vars and check it',  () => {
     cy.runApplicationsTest('gitHubAndEnvVar');
   });
 

--- a/cypress/integration/unit_tests/configurations.spec.ts
+++ b/cypress/integration/unit_tests/configurations.spec.ts
@@ -39,7 +39,7 @@ describe('Configuration testing', () => {
     });
   });
 
-  it.only('Create an application with a configuration, unbind the configuration and delete all', () => {
+  it('Create an application with a configuration, unbind the configuration and delete all', () => {
     cy.runConfigurationsTest('newAppWithConfiguration');
   });
 

--- a/cypress/integration/unit_tests/configurations.spec.ts
+++ b/cypress/integration/unit_tests/configurations.spec.ts
@@ -20,7 +20,7 @@ describe('Configuration testing', () => {
     cy.clickEpinioMenu('Applications');
     cy.get('body').then(($body) => {
       if ($body.text().includes('testapp')) {
-        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.get('[width="30"] > .checkbox-outer-container.check').click();
         cy.clickButton('Delete');
         cy.confirmDelete();
         cy.contains('testapp', {timeout: 60000}).should('not.exist');
@@ -31,7 +31,7 @@ describe('Configuration testing', () => {
     cy.clickEpinioMenu('Configurations');
     cy.get('body').then(($body) => {
       if ($body.text().includes('configuration01')) {
-        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.get('[width="30"] > .checkbox-outer-container.check').click();
         cy.clickButton('Delete');
         cy.confirmDelete();
         cy.contains('configurations01', {timeout: 60000}).should('not.exist');

--- a/cypress/integration/unit_tests/configurations.spec.ts
+++ b/cypress/integration/unit_tests/configurations.spec.ts
@@ -13,9 +13,33 @@ describe('Configuration testing', () => {
       topLevelMenu.openIfClosed();
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
+
+    // Executes application cleansing of "testapp" and "configuration01"
+    // Destroy application "testapp" and verify
+    // Could be a function later?
+    cy.clickEpinioMenu('Applications');
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('testapp')) {
+        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('testapp', {timeout: 60000}).should('not.exist');
+      };
+    });
+
+    // Destroy configuration "configuration01" and verify
+    cy.clickEpinioMenu('Configurations');
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('configuration01')) {
+        cy.get('[width="30"] > .checkbox-outer-container').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('configurations01', {timeout: 60000}).should('not.exist');
+      };
+    });
   });
 
-  it('Create an application with a configuration, unbind the configuration and delete all', () => {
+  it.only('Create an application with a configuration, unbind the configuration and delete all', () => {
     cy.runConfigurationsTest('newAppWithConfiguration');
   });
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -183,17 +183,18 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});       
         break; 
       case 'GitHub':
-        cy.typeValue({label: 'Username / Organization', value: 'epinio'}); 
-        cy.wait(1000)
+        cy.get('.labeled-input.edit.has-tooltip',{timeout:5000}).contains('label', 'Username / Organization').should('be.visible')
+        // Typing a bit slower to avoid fetching too early
+        cy.get('.labeled-input.edit.has-tooltip > input[type="text"]',{timeout:5000}).type('epinio',{delay:250, force:true})
         // Function 'typeValue' not working here
         // Selecting Repository
-        cy.get('.labeled-select.edit.hoverable').contains('label', 'Repository').click();
+        cy.get('.labeled-select.edit.hoverable',{timeout:5000}).contains('label', 'Repository').should('be.visible').click();
         cy.contains('example-go').click();
         // Selecting Branch
-        cy.get('.labeled-select.edit.hoverable').contains('label', 'Branch').click();
-        cy.contains('main').click();
+        cy.get('.labeled-select.edit.hoverable',{timeout:5000}).contains('label', 'Branch').should('be.visible').click();
+        cy.contains('main',{timeout:5000}).should('be.visible').click();
         // Selecting last commit. Currently at the top of the list.
-        cy.get('span.radio-custom').first().click();
+        cy.get('span.radio-custom',{timeout:5000}).first().should('be.visible').click();
         break;
     };
   };

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -180,10 +180,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         cy.typeValue({label: 'Branch', value: 'main'}); 
         break;
       case 'Archive':
-        cy.get('.archive input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});
-        // Locator changes on latest dashboard dev version. 
-        // Replace to this once upgraded.
-        // cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});       
+        cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});       
         break; 
       case 'GitHub':
         cy.typeValue({label: 'Username / Organization', value: 'epinio'}); 
@@ -195,7 +192,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         cy.get('.labeled-select.edit.hoverable').contains('label', 'Branch').click();
         cy.contains('main').click();
         // Selecting last commit
-        cy.get('span.radio-custom').last().click();
+        cy.get('span.radio-custom').first().click();
         break;
     };
   };

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -184,6 +184,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         break; 
       case 'GitHub':
         cy.typeValue({label: 'Username / Organization', value: 'epinio'}); 
+        cy.wait(1000)
         // Function 'typeValue' not working here
         // Selecting Repository
         cy.get('.labeled-select.edit.hoverable').contains('label', 'Repository').click();
@@ -191,7 +192,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         // Selecting Branch
         cy.get('.labeled-select.edit.hoverable').contains('label', 'Branch').click();
         cy.contains('main').click();
-        // Selecting last commit
+        // Selecting last commit. Currently at the top of the list.
         cy.get('span.radio-custom').first().click();
         break;
     };

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -75,6 +75,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.createService({ serviceName: customService, catalogType: customCatalog })
       cy.createApp( {appName: appName, archiveName: gitUrlWordpress, sourceType: 'Git URL', addVar: 'wordpress_env_file', serviceName: customService, catalogType: customCatalog });
       cy.checkApp({ appName: appName, dontCheckRouteAccess: true, serviceName: customService, checkCreatedApp: 'wordpress'});  
+      break;
     case 'gitHubAndEnvVar':
       cy.createApp({appName: appName, addVar: 'go_example', sourceType: 'GitHub'});
       cy.checkApp({appName: appName, checkVar: true});


### PR DESCRIPTION
Several fixes for e2e standalone ui  (related issue: https://github.com/epinio/epinio-end-to-end-tests/issues/218) including:

-  Locators updates.
-  Adding deletion of configuration and applications in Configuration tests.

Results: https://github.com/epinio/epinio-end-to-end-tests/runs/8308572073?check_suite_focus=true

![image](https://user-images.githubusercontent.com/37271841/189695069-a3578b18-e494-43ae-a7a5-f45b7c2c44da.png)



Additions:
- Improving locators for Github tests and slowing down typing repo name. Currently it is still disabled until further fix.