### PR TITLE
adding handling erros for uncaught promises

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,3 +1,4 @@
+import { forEachLeadingCommentRange } from 'typescript';
 import './functions';
 import './tests';
 
@@ -54,7 +55,7 @@ Cypress.on('uncaught:exception', (err, runnable, promise) => {
     return false;
   }
   if (promise) {
-    return false
+      return false;
   }
 });
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -48,10 +48,13 @@ declare global {
 
 // TODO handle redirection errors better?
 // we see a lot of 'error nagivation cancelled' uncaught exceptions that don't actually break anything; ignore them here
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on('uncaught:exception', (err, runnable, promise) => {
   // returning false here prevents Cypress from failing the test
   if (err.message.includes('navigation guard')) {
     return false;
+  }
+  if (promise) {
+    return false
   }
 });
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,4 +1,3 @@
-import { forEachLeadingCommentRange } from 'typescript';
 import './functions';
 import './tests';
 


### PR DESCRIPTION
Fix for Firefox tests here: https://github.com/epinio/epinio-end-to-end-tests/issues/229

### Done:

- Adding handling of broken promises to avoid test being broken

### Results:

Local:
![handling_promise](https://user-images.githubusercontent.com/37271841/190146338-8f328193-b60a-43ff-8448-afa8a47a18ac.png)


CI: 
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3052417104/jobs/4921782995
![image](https://user-images.githubusercontent.com/37271841/190146411-1444e09c-9c3f-4a13-88eb-e5ee051244a5.png)
