### PR TITLE
[Cypress] Adding test for login usernames with special characters

### DIFF
--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -83,4 +83,12 @@ describe('Login with different users', () => {
     cy.contains('Invalid username or password. Please try again.').should('not.exist')
     cy.contains('Applications').should('be.visible')
   });
+
+  it('Check login with admin user name with special character (user@test) and password also with special characters', () => {
+    const user_epinio = "user@test"
+    const pwd_epinio = "Hell@World"
+    cy.login(user_epinio, pwd_epinio);
+    cy.contains('Invalid username or password. Please try again.').should('not.exist')
+    cy.contains('Applications').should('be.visible')
+  });
 })

--- a/scripts/values-users.yaml
+++ b/scripts/values-users.yaml
@@ -15,5 +15,9 @@ api:
     - username: user2 
       passwordBcrypt: "$2y$10$I3/6py4jE4.P5IO1lWKg5e7D3.WQ8JKPX0kHTgPQPjW/h59utwzo6"
       role: user
+      #user@test password: Hell@World
+    - username: user@test 
+      passwordBcrypt: "$2y$10$xrZYXonrAnklLCURDX2zu.HacO02Fflp5toM/riJ028aNS2PJRutS"
+      role: admin
       workspaces:
         - workspace


### PR DESCRIPTION
Added UI automation for this issue: https://github.com/epinio/epinio/issues/1679
Related test for passwords: https://github.com/epinio/epinio-end-to-end-tests/pull/208

### Test implementation:
- Added UI test with special character username (user@test) . Password also contains special character to ensure it works.

Local test pass:
![special_login_characters](https://user-images.githubusercontent.com/37271841/190375207-245fd3f4-3d39-4b53-80d5-90d23ff96363.png)


CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3059323997/jobs/4936566901
![image](https://user-images.githubusercontent.com/37271841/190375371-4cf003f6-f13b-4c1b-8bd2-4e2a60e2642e.png)



