### PR TITLE
[Cypress] Adding UI test to check binaries link and version

### DIFF
--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -46,8 +46,64 @@ describe('Menu testing', () => {
     cy.clickButton('Create');
     // Check that the namespace has effectively been created
     cy.contains(defaultNamespace).should('be.visible');
-  }
-)});
+  });
+
+  it('Check binary links from version in menu', () => {
+    // Check link in main page is present and works after clicking
+    cy.get('.version.text-muted > a').should('have.attr', 'href').and('include', '/epinio/about');
+    cy.get('.version.text-muted > a').click();
+
+    // Test in ABOUT page strats here
+    cy.get('table > tr > td:nth-child(2)').eq(0).invoke('text').then(version => {
+      cy.log(`Epinio version in ABOUT PAGE is ${version}`);
+      // Check "Go back" link
+      cy.get('.back-link').should('exist').click();
+      cy.get('span.label.no-icon').eq(0).contains('Applications').should('be.visible');
+      // Checks version displayed in about page is the same as in main page
+      // Later returns to About page
+      cy.get('.version.text-muted > a').invoke('text').should('contains', version).then(version_main => {
+        cy.log(`Epinio version in MAIN UI is ${version_main}`);
+        cy.visit('/epinio/about');
+      });
+
+      // Check all links work and match the expected version
+
+      // Verify amount of binaries in the page 
+      cy.get('tr.link > td > a').should('have.length', 3);
+      const binOsNames = ['darwin-arm64', 'linux-arm64', 'windows-x86_64.zip'];
+
+      for (let i = 0; i < binOsNames.length; i++) {
+
+        // Verify binaries names and version match the one in the page
+        cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href').and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
+
+        // Download binaries
+        // This is added to workaround Cypress error waiting for a page instead of downloading
+        // Source: https://github.com/cypress-io/cypress/issues/14857#issuecomment-785717474 
+        cy.window().document().then(function (doc) {
+          doc.addEventListener('click', () => {
+            setTimeout(function () { doc.location.reload(); }, 5000);
+          });
+          // Now we can download
+          cy.get("tr.link > td > a").eq(i).click();
+        });
+
+        // Verify files are downloaded in cypress/download and its stdout output
+        cy.exec(`find "cypress/downloads/" -name "epinio-${binOsNames[i]}"`).its('stdout').should('contain', `${binOsNames[i]}`);
+      }
+
+      // Check link "See all packages" and visit binary page
+      // Check version number in binary page matches the one in Epinio
+      cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').then(() => {
+        cy.origin('https://github.com', { args: { version } }, ({ version }) => {
+          cy.visit(`/epinio/epinio/releases/tag/${version}`);
+          cy.get('.d-inline.mr-3').should('contain', `${version}`);
+          cy.screenshot(`epinio-bin-repo-${version}`);
+        });
+      });
+    });
+  });
+});
 
 // // Note: this test may need to be adapted with Rancher Dashboard
 describe('Login with different users', () => {

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -53,7 +53,7 @@ describe('Menu testing', () => {
     cy.get('.version.text-muted > a').should('have.attr', 'href').and('include', '/epinio/about');
     cy.get('.version.text-muted > a').click();
 
-    // Test in ABOUT page strats here
+    // Test in ABOUT page starts here
     cy.get('table > tr > td:nth-child(2)').eq(0).invoke('text').then(version => {
       cy.log(`Epinio version in ABOUT PAGE is ${version}`);
       // Check "Go back" link
@@ -75,7 +75,8 @@ describe('Menu testing', () => {
       for (let i = 0; i < binOsNames.length; i++) {
 
         // Verify binaries names and version match the one in the page
-        cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href').and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
+        cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
+        .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
 
         // Download binaries
         // This is added to workaround Cypress error waiting for a page instead of downloading
@@ -85,7 +86,8 @@ describe('Menu testing', () => {
             setTimeout(function () { doc.location.reload(); }, 5000);
           });
           // Now we can download
-          cy.get("tr.link > td > a").eq(i).click( {force: true} );
+          cy.get("tr.link > td > a").eq(i).click({ force: true });
+          // Adding a bit of wait prior executing command to ensure file is downloaded
           cy.wait(1500);
         });
 
@@ -95,7 +97,8 @@ describe('Menu testing', () => {
 
       // Check link "See all packages" and visit binary page
       // Check version number in binary page matches the one in Epinio
-      cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').then(() => {
+      cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').as('href_repo').then(() => {
+        cy.get('@href_repo').should('eq', `https://github.com/epinio/epinio/releases/tag/${version}`)
         cy.origin('https://github.com', { args: { version } }, ({ version }) => {
           cy.visit(`/epinio/epinio/releases/tag/${version}`);
           cy.get('.d-inline.mr-3').should('contain', `${version}`);
@@ -103,7 +106,7 @@ describe('Menu testing', () => {
         });
       });
     });
-  });
+  }); 
 });
 
 // // Note: this test may need to be adapted with Rancher Dashboard

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -85,11 +85,12 @@ describe('Menu testing', () => {
             setTimeout(function () { doc.location.reload(); }, 5000);
           });
           // Now we can download
-          cy.get("tr.link > td > a").eq(i).click();
+          cy.get("tr.link > td > a").eq(i).click( {force: true} );
+          cy.wait(1500);
         });
 
         // Verify files are downloaded in cypress/download and its stdout output
-        cy.exec(`find "cypress/downloads/" -name "epinio-${binOsNames[i]}"`).its('stdout').should('contain', `${binOsNames[i]}`);
+        cy.exec(`find "cypress/downloads/" -name "epinio-${binOsNames[i]}*"`).its('stdout').should('contain', `${binOsNames[i]}`);
       }
 
       // Check link "See all packages" and visit binary page


### PR DESCRIPTION
Automated test for: https://github.com/epinio/epinio-end-to-end-tests/issues/214

### Implemented:
- Bottom link with version number takes user to `about page` with binaries
- Version number from About page matches the one in main
- Back button works
- All links work
- Binaries are downloaded and names are checked in the download folder
- `See all packages` link takes the user to the right version, checks element in page and takes screenshot
- Version number is checked for all links

### Local results:
![2022-09-19_16-24](https://user-images.githubusercontent.com/37271841/191043811-9a75fc09-d882-4795-9aaa-9cb210b3ed73.png)
![2022-09-19_16-25](https://user-images.githubusercontent.com/37271841/191043808-e92b8595-f32c-4c67-9dd6-8a1f42c85238.png)

### CI results:
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3088337610/jobs/4994689441
![image](https://user-images.githubusercontent.com/37271841/191200816-9fdbe1c3-39b2-470d-831e-d020500028d3.png)

