### PR TITLE
Rancher UI tests without Epinio icon

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -181,6 +181,7 @@ jobs:
   cypress-epinio-tests:
     needs:
       - installation
+      - cypress-epinio-installation
       - epinio-patching
     runs-on: ${{ inputs.runner }}
     container:
@@ -188,21 +189,20 @@ jobs:
       env:
         CLUSTER_NAME: local
         RANCHER_USER: admin
-        RANCHER_PASSWORD: rancherpassword
-        RANCHER_URL: https://${{ needs.installation.outputs.MY_HOSTNAME }}/dashboard
+        RANCHER_PASSWORD: password
+        RANCHER_URL: https://epinio.${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
-        UI: rancher
+        # set UI value to something else than 'rancher'
+        UI: epinio-rancher
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
-
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
           browser: ${{ inputs.browser }}
           headless: true
           spec: |
-            cypress/integration/scenarios/${{ inputs.cypress_test }}
-            cypress/integration/unit_tests/uninstall.spec.ts
+            cypress/integration/unit_tests/${{ inputs.cypress_test }}
           config-file: cypress-with-epinio-cert.json
 
       - name: Upload Cypress screenshots
@@ -222,9 +222,54 @@ jobs:
           path: cypress/videos
           retention-days: 7
 
+  cypress-epinio-uninstall:
+    needs:
+      - installation
+      - cypress-epinio-installation
+      - epinio-patching
+      - cypress-epinio-tests
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.cypress_image }}
+      env:
+        CLUSTER_NAME: local
+        RANCHER_USER: admin
+        RANCHER_PASSWORD: rancherpassword
+        RANCHER_URL: https://${{ needs.installation.outputs.MY_HOSTNAME }}/dashboard
+        SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
+        UI: rancher
+      options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME}}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
+    steps:
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          browser: ${{ inputs.browser }}
+          headless: true
+          spec: |
+            cypress/integration/unit_tests/uninstall.spec.ts
+          config-file: cypress-with-epinio-cert.json
+
+      - name: Upload Cypress screenshots
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots-uninstall
+          path: cypress/screenshots
+          retention-days: 7
+
+      # Test run video was always captured, so this action uses "always()" condition
+      - name: Upload Cypress videos
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-videos-uninstall
+          path: cypress/videos
+          retention-days: 7
+
   delete-cluster:
     if: always()
-    needs: [installation, cypress-epinio-installation, epinio-patching, cypress-epinio-tests]
+    needs: [installation, cypress-epinio-installation, epinio-patching, cypress-epinio-tests, cypress-epinio-uninstall]
     runs-on: ${{ inputs.runner }}
     steps:
 

--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -14,7 +14,8 @@ jobs:
       browser: chrome
       cypress_image: cypress/browsers:node16.13.2-chrome97-ff96
       cypress_install_test: installation.spec.ts
-      cypress_test: with_default_options.spec.ts
+      # cypress_test: with_default_options.spec.ts
+      cypress_test: menu.spec.ts
       runner: ui-e2e-0
     secrets:
       ext_reg_user: secrets.EPINIO_DOCKER_USER

--- a/.github/workflows/scenario_2_firefox_rancher_ui.yml
+++ b/.github/workflows/scenario_2_firefox_rancher_ui.yml
@@ -14,14 +14,15 @@ jobs:
       browser: firefox
       cypress_image: cypress/browsers:node16.13.2-chrome97-ff96
       cypress_install_test: installation.spec.ts
-      cypress_test: with_s3_and_external_registry.spec.ts
+      # cypress_test: with_s3_and_external_registry.spec.ts
+      cypress_test: menu.spec.ts
       # Due to security reason, Firefox can't be started as root
       # https://github.com/cypress-io/github-action#firefox
       docker_options: '--user 1000'
       runner: ui-e2e-2
-      ext_reg: '1'
+      # ext_reg: '1'
     secrets:
       ext_reg_user: secrets.EPINIO_DOCKER_USER
       ext_reg_password: secrets.EPINIO_DOCKER_PASSWORD
-      s3_key_id: secrets.AWS_ACCESS_KEY_ID
-      s3_key_secret: secrets.AWS_SECRET_ACCESS_KEY
+      # s3_key_id: secrets.AWS_ACCESS_KEY_ID
+      # s3_key_secret: secrets.AWS_SECRET_ACCESS_KEY

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ make cypress-gui
 ```
 
 ## Scenario 1 - Using Chrome
-In this first scenario, Epinio is deployed with default options. </br>
-You can check all the things we test directly in the [file](./cypress/integration/scenarios/with_default_options.spec.ts).
+In this first scenario, Epinio is deployed in Rancher with default options. </br>
+And then basic UI test is performed [menu.spec.ts](./cypress/integration/unit_tests/menu.spec.ts).
+<!-- You can check all the things we test directly in the [file](./cypress/integration/scenarios/with_default_options.spec.ts). -->
 
 ## Scenario 2 - Using Firefox
-Second scenario tests Epinio installation with S3 and external registry configured. </br>
-Unlike the first scenario, we only play a small bunch of [tests](./cypress/integration/scenarios/with_s3_and_external_registry.spec.ts).
+Second scenario is the same as the first one just performed in Firefox. </br>
+TODO: Get back installation with S3 and external registry configuration within rancher installation. Ref. [Issue#236](https://github.com/epinio/epinio-end-to-end-tests/issues/236)
+<!-- Second scenario tests Epinio installation with S3 and external registry configured. </br>
+Unlike the first scenario, we only play a small bunch of [tests](./cypress/integration/scenarios/with_s3_and_external_registry.spec.ts). -->
 
 ## Process explained in one chart
 ```mermaid

--- a/cypress/integration/unit_tests/installation.spec.ts
+++ b/cypress/integration/unit_tests/installation.spec.ts
@@ -21,4 +21,23 @@ describe('Epinio installation testing', () => {
     // Boolean must be forced to false otherwise code is failing
     cy.epinioInstall({s3: false, extRegistry: false});
   });
+
+  it('Verify Epinio over ingress URL', () => {
+    // WORKAROUND until Epinio icon will be present again in Rancher UI
+    cy.contains('More Resources').click();
+    cy.contains('Networking').click();
+    cy.contains('Ingresses').click();
+    cy.contains('.ingress-target .target > a', 'epinio-ui')
+      .prevAll('a')
+      .invoke('attr', 'href').then( (href) => {
+        cy.origin(href, (href) => {
+        cy.visit('/');
+        cy.get('h1').contains('Welcome to Epinio').should('be.visible')
+        cy.url().then(url => {
+          const tempUrl= url.replace(/^(https:\/\/.*?)\/.*$/, "$1");
+          cy.log(`Epinio URL from ingress: ${tempUrl}`);
+        });
+      });
+    });
+  });
 });

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -11,7 +11,7 @@ describe('Menu testing', () => {
     cy.login();
     cy.visit('/');
   });
-  
+
   it('Check Epinio menu', () => {
     if (Cypress.env('ui') == "rancher") {
       topLevelMenu.openIfClosed();
@@ -19,7 +19,7 @@ describe('Menu testing', () => {
       // Epinio's icon should appear in the side menu
       epinio.epinioIcon().should('exist');
 
-      // Click on the Epinio's logo as well as your Epinio instance 
+      // Click on the Epinio's logo as well as your Epinio instance
       epinio.accessEpinioMenu(Cypress.env('cluster')); 
     }
 
@@ -68,7 +68,7 @@ describe('Menu testing', () => {
 
       // Check all links work and match the expected version
 
-      // Verify amount of binaries in the page 
+      // Verify amount of binaries in the page
       cy.get('tr.link > td > a').should('have.length', 3);
       const binOsNames = ['darwin-arm64', 'linux-arm64', 'windows-x86_64.zip'];
 
@@ -80,7 +80,7 @@ describe('Menu testing', () => {
 
         // Download binaries
         // This is added to workaround Cypress error waiting for a page instead of downloading
-        // Source: https://github.com/cypress-io/cypress/issues/14857#issuecomment-785717474 
+        // Source: https://github.com/cypress-io/cypress/issues/14857#issuecomment-785717474
         cy.window().document().then(function (doc) {
           doc.addEventListener('click', () => {
             setTimeout(function () { doc.location.reload(); }, 5000);
@@ -106,10 +106,12 @@ describe('Menu testing', () => {
         });
       });
     });
-  }); 
+  });
 });
 
-// // Note: this test may need to be adapted with Rancher Dashboard
+// Note: this test needs to be adapted for Rancher Dashboard
+// Currently we are good if the custom user is unable to login when chart installed over Rancher
+// We'd need to apply values.yaml with the users first in Edit YAML
 describe('Login with different users', () => {
 
   it('Check login with admin user', () => {
@@ -132,23 +134,53 @@ describe('Login with different users', () => {
     const user_epinio = "user1"
     const pwd_epinio = "Hell@World"
     cy.login(user_epinio, pwd_epinio);
-    cy.contains('Invalid username or password. Please try again.').should('not.exist')
-    cy.contains('Applications').should('be.visible')
+    if (Cypress.env('ui') == null ) {
+      cy.contains('Invalid username or password. Please try again.').should('not.exist')
+      cy.contains('Applications').should('be.visible')
+    }
+    // Login fails when installed from rancher
+    else if (Cypress.env('ui') == 'epinio-rancher' || Cypress.env('ui') == 'rancher') {
+      cy.contains('Invalid username or password. Please try again.').should('exist')
+      cy.exec('echo "Negative testing for users. This user not allowed to log in unless values-users.yaml is applied."')
+    }
+    else {
+      throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
+    }
   });
 
   it('Check login with regular user "user2" and password with many special characters', () => {
     const user_epinio = "user2"
     const pwd_epinio = "Hell#@~%/=World"
     cy.login(user_epinio, pwd_epinio);
-    cy.contains('Invalid username or password. Please try again.').should('not.exist')
-    cy.contains('Applications').should('be.visible')
+    if (Cypress.env('ui') == null ) {
+      cy.contains('Invalid username or password. Please try again.').should('not.exist')
+      cy.contains('Applications').should('be.visible')
+    }
+    // Login fails when installed from rancher
+    else if (Cypress.env('ui') == 'epinio-rancher' || Cypress.env('ui') == 'rancher') {
+      cy.contains('Invalid username or password. Please try again.').should('exist')
+      cy.exec('echo "Negative testing for users. This user not allowed to log in unless values-users.yaml is applied."')
+    }
+    else {
+      throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
+    }
   });
 
   it('Check login with admin user name with special character (user@test) and password also with special characters', () => {
     const user_epinio = "user@test"
     const pwd_epinio = "Hell@World"
     cy.login(user_epinio, pwd_epinio);
-    cy.contains('Invalid username or password. Please try again.').should('not.exist')
-    cy.contains('Applications').should('be.visible')
+    if (Cypress.env('ui') == null ) {
+      cy.contains('Invalid username or password. Please try again.').should('not.exist')
+      cy.contains('Applications').should('be.visible')
+    }
+    // Login fails when installed from rancher
+    else if (Cypress.env('ui') == 'epinio-rancher' || Cypress.env('ui') == 'rancher') {
+      cy.contains('Invalid username or password. Please try again.').should('exist')
+      cy.exec('echo "Negative testing for users. This user not allowed to log in unless values-users.yaml is applied."')
+    }
+    else {
+      throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
+    }
   });
 })

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -53,8 +53,11 @@ Cypress.on('uncaught:exception', (err, runnable, promise) => {
   if (err.message.includes('navigation guard')) {
     return false;
   }
+  if (err.message.includes('on cross-origin object')) {
+    return false;
+  }
   if (promise) {
-      return false;
+    return false;
   }
 });
 


### PR DESCRIPTION
Rancher UI tests now using epinio ingress url address link instead of Epinio icon which is not available anymore.

* I had to split cypress UI `master_rancher_ui_workflow.yml` into three steps, each with its own env vars to be able login to corresponding service (rancher and epinio): 
  - epinio installation in rancher UI
  - ~epino testing by new `rancher-menu.spec.ts` - basically slightly adapted `menu.spec.ts` (without login of different users)~  menu.spec.ts has been adapted in the end
  - epinio uninstalllation in rancher UI
* replaced the scenarios `with_default_options.spec.ts` (chrome) and `with_s3_and_external_registry.spec.ts` (firefox) by simple unit_test `menu.spec.ts`
* external registries are not tested anymore in Rancher UI tests

TODO:
- [x] get rid of rancher-menu.spec.ts + use menu.spec.ts and extend it by `if (ui != 'rancher)` condition.
- ~[ ] re-enable external registries - and use rancher ui form for entering s3 credentials & co.~ subject of https://github.com/epinio/epinio-end-to-end-tests/issues/236