### PR TITLE
bump cypress to k3s v1.24.6+k3s1

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -66,7 +66,7 @@ jobs:
           DASHBOARD_VERSION: epinio-dev
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
-          K3S_VERSION: v1.22.7+k3s1
+          K3S_VERSION: v1.24.6+k3s1
           EXT_REG: ${{ inputs.ext_reg }}
           EXT_REG_USER: ${{ secrets.ext_reg_user }}
           EXT_REG_PASSWORD: ${{ secrets.ext_reg_password }}

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
-          K3S_VERSION: v1.22.7+k3s1
+          K3S_VERSION: v1.24.6+k3s1
           EXT_REG: ${{ inputs.ext_reg }}
           S3: ${{ inputs.s3 }}
           EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}


### PR DESCRIPTION

UI tests seem to be ok after this bump:

- [Rancher-UI-2-Firefox Rancher-UI-2-Firefox #304](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3218931238/jobs/5264012402) -> OK
- [Rancher-UI-1-Chrome Rancher-UI-1-Chrome #281](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3219475022) -> OK
- [STD-UI-Latest-Firefox STD-UI-Latest-Firefox #133](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3218860701) -> OK
- [STD-UI-Latest-Chrome STD-UI-Latest-Chrome #209](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3219230238/jobs/5264344093) -> OK, with 1 single failure; seems corner case