### PR TITLE
Cypress/refactor config app deletion

### DIFF
--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -36,14 +36,7 @@ describe('Menu testing', () => {
   });
 
   it('Verify Welcome Screen without Namespaces', () => {
-    cy.clickEpinioMenu('Namespaces');
-    // Deletes all namespaces if detected
-    cy.get("body").then(($body) => {
-      if ($body.text().includes('Delete')) {
-        cy.deleteAllNamespaces()
-      }
-     }
-    )
+    cy.deleteAll('Namespaces')
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio').should('be.visible')
     // Verify creating namespace from Get Started button works
@@ -67,8 +60,8 @@ describe('Applications testing', () => {
     }
 
     // Delete all Apps and Configurations that may exist
-    cy.deleteAllApplications()
-    cy.deleteAllConfigurations()
+    cy.deleteAll('Applications')
+    cy.deleteAll('Configurations')
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/integration/scenarios/with_default_options.spec.ts
+++ b/cypress/integration/scenarios/with_default_options.spec.ts
@@ -65,29 +65,10 @@ describe('Applications testing', () => {
       topLevelMenu.openIfClosed();
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
-    // Executes application cleansing of "testapp" and "configuration01"
-    // Destroy application "testapp" and verify
-    // Could be a function later?
-    cy.clickEpinioMenu('Applications');
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('testapp')) {
-        cy.get('[width="30"] > .checkbox-outer-container').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('testapp', {timeout: 60000}).should('not.exist');
-      };
-    });
 
-    // Destroy configuration "configuration01" and verify
-    cy.clickEpinioMenu('Configurations');
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('configuration01')) {
-        cy.get('[width="30"] > .checkbox-outer-container').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('configurations01', {timeout: 60000}).should('not.exist');
-      };
-    });
+    // Delete all Apps and Configurations that may exist
+    cy.deleteAllApplications()
+    cy.deleteAllConfigurations()
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
+++ b/cypress/integration/scenarios/with_s3_and_external_registry.spec.ts
@@ -36,14 +36,7 @@ describe('Menu testing', () => {
   });
 
   it('Verify Welcome Screen without Namespaces', () => {
-    cy.clickEpinioMenu('Namespaces');
-    // Deletes all namespaces if detected
-    cy.get("body").then(($body) => {
-      if ($body.text().includes('Delete')) {
-        cy.deleteAllNamespaces()
-      }
-     }
-    )
+    cy.deleteAll('Namespaces')
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio').should('be.visible')
     // Verify creating namespace from Get Started button works

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -18,7 +18,7 @@ describe('Applications testing', () => {
     cy.deleteAllConfigurations()
   });
 
-  it.only('Push basic application and check we can restart and rebuild it', () => {
+  it('Push basic application and check we can restart and rebuild it', () => {
     cy.runApplicationsTest('restartAndRebuild');
   });
 

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -13,33 +13,12 @@ describe('Applications testing', () => {
       topLevelMenu.openIfClosed();
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
-
-    // Executes application cleansing of "testapp" and "configuration01"
-    // Destroy application "testapp" and verify
-    // Could be a function later?
-    cy.clickEpinioMenu('Applications');
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('testapp')) {
-        cy.get('[width="30"] > .checkbox-outer-container.check').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('testapp', {timeout: 60000}).should('not.exist');
-      };
-    });
-
-    // Destroy configuration "configuration01" and verify
-    cy.clickEpinioMenu('Configurations');
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('configuration01')) {
-        cy.get('[width="30"] > .checkbox-outer-container.check').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('configurations01', {timeout: 60000}).should('not.exist');
-      };
-    });
+    // Delete all Apps and Configurations that may exist
+    cy.deleteAllApplications()
+    cy.deleteAllConfigurations()
   });
 
-  it('Push basic application and check we can restart and rebuild it', () => {
+  it.only('Push basic application and check we can restart and rebuild it', () => {
     cy.runApplicationsTest('restartAndRebuild');
   });
 

--- a/cypress/integration/unit_tests/applications.spec.ts
+++ b/cypress/integration/unit_tests/applications.spec.ts
@@ -14,8 +14,8 @@ describe('Applications testing', () => {
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
     // Delete all Apps and Configurations that may exist
-    cy.deleteAllApplications()
-    cy.deleteAllConfigurations()
+    cy.deleteAll('Applications')
+    cy.deleteAll('Configurations')
   });
 
   it('Push basic application and check we can restart and rebuild it', () => {

--- a/cypress/integration/unit_tests/configurations.spec.ts
+++ b/cypress/integration/unit_tests/configurations.spec.ts
@@ -14,29 +14,9 @@ describe('Configuration testing', () => {
       epinio.accessEpinioMenu(Cypress.env('cluster'));
     }
 
-    // Executes application cleansing of "testapp" and "configuration01"
-    // Destroy application "testapp" and verify
-    // Could be a function later?
-    cy.clickEpinioMenu('Applications');
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('testapp')) {
-        cy.get('[width="30"] > .checkbox-outer-container.check').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('testapp', {timeout: 60000}).should('not.exist');
-      };
-    });
-
-    // Destroy configuration "configuration01" and verify
-    cy.clickEpinioMenu('Configurations');
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('configuration01')) {
-        cy.get('[width="30"] > .checkbox-outer-container.check').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('configurations01', {timeout: 60000}).should('not.exist');
-      };
-    });
+    // Delete all Apps and Configurations that may exist
+    cy.deleteAllApplications()
+    cy.deleteAllConfigurations()
   });
 
   it('Create an application with a configuration, unbind the configuration and delete all', () => {

--- a/cypress/integration/unit_tests/configurations.spec.ts
+++ b/cypress/integration/unit_tests/configurations.spec.ts
@@ -15,8 +15,8 @@ describe('Configuration testing', () => {
     }
 
     // Delete all Apps and Configurations that may exist
-    cy.deleteAllApplications()
-    cy.deleteAllConfigurations()
+    cy.deleteAll('Applications')
+    cy.deleteAll('Configurations')
   });
 
   it('Create an application with a configuration, unbind the configuration and delete all', () => {

--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -28,14 +28,7 @@ describe('Menu testing', () => {
   });
 
   it('Verify Welcome Screen without Namespaces', () => {
-    cy.clickEpinioMenu('Namespaces');
-    // Deletes all namespaces if detected
-    cy.get("body").then(($body) => {
-      if ($body.text().includes('Delete')) {
-        cy.deleteAllNamespaces()
-      }
-     }
-    )
+    cy.deleteAll('Namespaces')
     cy.clickEpinioMenu('Applications');
     cy.get('h1').contains('Welcome to Epinio').should('be.visible')
     // Verify creating namespace from Get Started button works

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -78,6 +78,20 @@ Cypress.Commands.add('confirmDelete', (namespace) => {
   cy.get('.card-actions').contains('Delete').click();
 });
 
+Cypress.Commands.add('deleteAll', (label) => {
+  // Must be present in Configurations, Aplications or Namespaces page first
+  cy.clickEpinioMenu(label)
+  cy.get('h1').contains(label).should('be.visible')
+  cy.log(`## DElETION OF ALL ${label} STARTS HERE ##`)
+  cy.get('body').then(($body) => {
+    if ($body.text().includes('Delete')) {
+      cy.get('[width="30"] > .checkbox-outer-container.check').click();
+      cy.get('.btn').contains('Delete').click({ctrlKey: true});
+      cy.get('#promptRemove', {timeout: 40000}).should('not.exist')
+    };
+  });
+});
+
 // Check the status of the running stage
 Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, status='Success'}) => {
   var getScope = ':nth-child(' + numIndex + ') > .col-badge-state-formatter > .status > .badge';
@@ -519,47 +533,6 @@ Cypress.Commands.add('deleteNamespace', ({namespace, appName}) => {
     cy.contains(appName).should('not.exist');
   }
 });
-
-// Delete all Namespaces
-Cypress.Commands.add('deleteAllNamespaces', () => {
-  cy.clickEpinioMenu('Namespaces')
-  cy.get('.checkbox-outer-container.check').click();
-  // Mimics Ctrl + click Delete to destroy all Namespaces
-  cy.get('.btn').contains('Delete').click({ctrlKey: true});
-  cy.get('#promptRemove', {timeout: 25000}).should('not.exist')
-});
-
-// Delete all Applications
-Cypress.Commands.add('deleteAllApplications', () => {
-  cy.clickEpinioMenu('Applications');
-  cy.get('h1').contains('Applications').should('be.visible')
-  cy.log('APP DELETION STARTS HERE')
-  // cy.wait(50000)
-    cy.get('body').then(($body) => {
-      if ($body.text().includes('Namespace:')) {
-        cy.get('[width="30"] > .checkbox-outer-container.check').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('Namespace:', {timeout: 60000}).should('not.exist');
-      };
-    });
-  });
-
-// Delete all Configurations
-Cypress.Commands.add('deleteAllConfigurations', () => {
-  cy.clickEpinioMenu('Configurations');
-  cy.log('CONFIG DELETION STARTS HERE')
-  cy.get('h1').contains('Configurations').should('be.visible')
-    cy.get('body').then(($body) => {
-      
-      if ($body.text().includes('Namespace:')) {
-        cy.get('[width="30"] > .checkbox-outer-container.check').click();
-        cy.clickButton('Delete');
-        cy.confirmDelete();
-        cy.contains('Namespace:', {timeout: 60000}).should('not.exist');
-      };
-    });
-  });
 
 // Configurations functions
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -58,10 +58,9 @@ Cypress.Commands.add('clickEpinioMenu', (label) => {
   // This will check application menu regardles if it has namespaces
   cy.get("body").then(($body) => {
     if ($body.text().includes('Routes')) {
-      cy.contains('.m-0', 'Applications', {timeout: 20000}).should('be.exist');
+      cy.contains('.m-0', 'Applications', {timeout: 20000}).should('be.visible');
     } else if ($body.text().includes('Welcome to Epinio')) {
       cy.get('h1').contains('Welcome to Epinio', {timeout: 4000}).should('be.visible')}});
-  
 });
 
 // Confirm the delete operation
@@ -529,6 +528,38 @@ Cypress.Commands.add('deleteAllNamespaces', () => {
   cy.get('.btn').contains('Delete').click({ctrlKey: true});
   cy.get('#promptRemove', {timeout: 25000}).should('not.exist')
 });
+
+// Delete all Applications
+Cypress.Commands.add('deleteAllApplications', () => {
+  cy.clickEpinioMenu('Applications');
+  cy.get('h1').contains('Applications').should('be.visible')
+  cy.log('APP DELETION STARTS HERE')
+  // cy.wait(50000)
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('Namespace:')) {
+        cy.get('[width="30"] > .checkbox-outer-container.check').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('Namespace:', {timeout: 60000}).should('not.exist');
+      };
+    });
+  });
+
+// Delete all Configurations
+Cypress.Commands.add('deleteAllConfigurations', () => {
+  cy.clickEpinioMenu('Configurations');
+  cy.log('CONFIG DELETION STARTS HERE')
+  cy.get('h1').contains('Configurations').should('be.visible')
+    cy.get('body').then(($body) => {
+      
+      if ($body.text().includes('Namespace:')) {
+        cy.get('[width="30"] > .checkbox-outer-container.check').click();
+        cy.clickButton('Delete');
+        cy.confirmDelete();
+        cy.contains('Namespace:', {timeout: 60000}).should('not.exist');
+      };
+    });
+  });
 
 // Configurations functions
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -10,6 +10,7 @@ declare global {
       login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;
+      deleteAll(label: string,):Chainable<Element>;
       clickEpinioMenu(label: string,): Chainable<Element>;
       clickClusterMenu(listLabel: string[],): Chainable<Element>;
       confirmDelete(namespace?: string,): Chainable<Element>;
@@ -20,7 +21,6 @@ declare global {
       createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string ): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
-      deleteAllApplications():Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;
       rebuildApp(appName: string, namespace?: string,): Chainable<Element>;
       showAppLog(appName: string, namespace?: string,): Chainable<Element>;
@@ -28,11 +28,9 @@ declare global {
       downloadManifest(appName: string): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
-      deleteAllNamespaces():Chainable<Element>;
       createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       editConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;
-      deleteAllConfigurations():Chainable<Element>;
       createService(serviceName: string, catalogType: string): Chainable<Element>;
       bindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;
       unbindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -20,6 +20,7 @@ declare global {
       createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string ): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
+      deleteAllApplications():Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;
       rebuildApp(appName: string, namespace?: string,): Chainable<Element>;
       showAppLog(appName: string, namespace?: string,): Chainable<Element>;
@@ -31,6 +32,7 @@ declare global {
       createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       editConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;
+      deleteAllConfigurations():Chainable<Element>;
       createService(serviceName: string, catalogType: string): Chainable<Element>;
       bindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;
       unbindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;


### PR DESCRIPTION
Refactoring deletion of all namespaces, configurations and applications into 1 single function.

It just needs to call function `deleteAll` and pass as parameter inside '**Configurations**',  '**Namespaces**' or '**Applications**'.
The function searches if delete button exists. If true, effectively clicks on it waiting until it disappears (deletion is complete) and if false let the test continues.