### PR TITLE
freezing dashboard image to v1.2.0.0.0.1

### DIFF
--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -25,7 +25,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: rancher/dashboard
-        ref: epinio-dev
+        # Momentarily freezing latest version until epinio-dev is stable
+        # https://github.com/epinio/epinio-end-to-end-tests/issues/247
+        # ref: epinio-dev
+        ref: epinio-standalone-v1.2.0.0.0.1 
         path: dashboard
 
     - uses: actions/setup-node@v2

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -54,7 +54,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: rancher/dashboard
-          ref: epinio-dev
+          # Momentarily freezing latest version until epinio-dev is stable
+          # https://github.com/epinio/epinio-end-to-end-tests/issues/247
+          # ref: epinio-dev
+          ref: epinio-standalone-v1.2.0.0.0.1
           path: dashboard
 
       - name: Checkout Epinio UI-backend repository


### PR DESCRIPTION
Fix for https://github.com/epinio/epinio-end-to-end-tests/issues/247

We freezing latest qa image from https://github.com/rancher/dashboard/tree/epinio-dev to  `epinio-standalone-v1.2.0.0.0.1` due to instability  on `epinio-dev`.

This will be reverted once stable

Checked on: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3274389955/jobs/5387848491
![image](https://user-images.githubusercontent.com/37271841/196465721-d5e8a642-0ff7-4171-9571-31ccf3a4034e.png)

