### PR TITLE
adding login test username numeric

### DIFF
--- a/cypress/integration/unit_tests/menu.spec.ts
+++ b/cypress/integration/unit_tests/menu.spec.ts
@@ -176,4 +176,23 @@ describe('Login with different users', () => {
       throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
     }
   });
+
+  it('Check login with admin user name with numbers (0123456789) and password', () => {
+    const user_epinio = "0123456789"
+    const pwd_epinio = "password"
+    cy.login(user_epinio, pwd_epinio);
+    if (Cypress.env('ui') == null) {
+      cy.contains('Invalid username or password. Please try again.').should('not.exist')
+      cy.contains('Applications').should('be.visible')
+    }
+    // Login fails when installed from rancher
+    else if (Cypress.env('ui') == 'epinio-rancher' || Cypress.env('ui') == 'rancher') {
+      cy.contains('Invalid username or password. Please try again.').should('exist')
+      cy.exec('echo "Negative testing for users. This user not allowed to log in unless values-users.yaml is applied."')
+    }
+    else {
+      throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
+    }
+  });
+
 })

--- a/scripts/values-users.yaml
+++ b/scripts/values-users.yaml
@@ -7,6 +7,9 @@ api:
     - username: epinio
       passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
       role: user
+    - username: "0123456789"
+      passwordBcrypt: "$2a$10$6bCi5NMstMK781In7JGiL.B44pgoplUb330FQvm6mVXMppbXBPiXS"
+      role: admin
       #user1 password: Hell@World
     - username: user1 
       passwordBcrypt: "$2y$10$xrZYXonrAnklLCURDX2zu.HacO02Fflp5toM/riJ028aNS2PJRutS"


### PR DESCRIPTION
PR for https://github.com/epinio/epinio-end-to-end-tests/issues/248
Covers automated test of https://github.com/epinio/epinio/issues/1728

### Test purpose:
Adding loging username as number

### Results:

#### Local:
![login_0123456789](https://user-images.githubusercontent.com/37271841/196676677-e1041275-703a-4753-885a-f4479276d46f.png)

#### CI: [STD-UI-Latest-Chrome #227](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3280992702/jobs/5402452047)

![image](https://user-images.githubusercontent.com/37271841/196676577-4b185b6e-1d79-4bae-b8f0-ccd0e017d0c2.png)

