### PR TITLE
Cypress/update customvalue servicewordpresstest

### DIFF
--- a/cypress/fixtures/read_from_worpress_file.txt
+++ b/cypress/fixtures/read_from_worpress_file.txt
@@ -1,4 +1,4 @@
 BP_PHP_VERSION=8.0.x
 BP_PHP_SERVER=nginx
 BP_PHP_WEB_DIR=wordpress 
-CONFIG_NAME=x5dc8835923fe6cac2053d8aa18b1-mysql
+CONFIG_NAME=x8e5ee833a0f2faebaf5c4171baca-mysql

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -277,7 +277,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
     cy.get('.key > input').eq(2).should('have.value', 'BP_PHP_WEB_DIR');
     cy.get('.no-resize').eq(2).should('have.value', 'wordpress ');
     cy.get('.key > input').eq(3).should('have.value', 'CONFIG_NAME');
-    cy.get('.no-resize').eq(3).should('have.value', 'x5dc8835923fe6cac2053d8aa18b1-mysql');
+    cy.get('.no-resize').eq(3).should('have.value', 'x8e5ee833a0f2faebaf5c4171baca-mysql');
   }
 
   if (addVar === 'go_example') {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -630,7 +630,7 @@ Cypress.Commands.add('createService', ({serviceName, catalogType}) => {
   cy.get('span.vs__selected').eq(1).should('contain', catalogType )
   cy.clickButton('Create');
   // Verify service is deployed 
-  cy.get('span.badge-state.bg-success', {timeout: 60000}).contains('Deployed').should('be.visible')
+  cy.get('span.badge-state.bg-success', {timeout: 90000}).contains('Deployed').should('be.visible')
   cy.get('td.col-link-detail').eq(0).contains(serviceName).should('be.visible')
 });
 


### PR DESCRIPTION
### Updates on application's test `Create mysql service, bind it to a Wordpress app and push it`:


- Updated env var `CONFIG_NAME` to `x8e5ee833a0f2faebaf5c4171baca-mysql`  in file [read_from_worpress_file.txt](https://github.com/epinio/epinio-end-to-end-tests/files/9851514/read_from_worpress_file.txt) since the past env var got outdated and did not displayed correctly the deployed Wordpress page
- Extended implicit wait for custom service creation from 60 to 90s

### CI tests passing: 
[STD-UI-Latest-Chrome #239](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3312232681/jobs/5468652510)

![image](https://user-images.githubusercontent.com/37271841/197522537-59973c8e-e67d-4a23-acc5-ae048354762a.png)

### Local tests:
![2022-10-24_12-15](https://user-images.githubusercontent.com/37271841/197522675-48df44c4-dd89-4133-99d9-f66981fd0ea0.png)
![2022-10-24_12-16_1](https://user-images.githubusercontent.com/37271841/197522686-884202e6-6026-42a1-83ed-04cf18bbccd6.png)

