### PR TITLE
Bring back qa latest image to `epinio-dev` again

### DIFF
--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -25,10 +25,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: rancher/dashboard
-        # Momentarily freezing latest version until epinio-dev is stable
-        # https://github.com/epinio/epinio-end-to-end-tests/issues/247
-        # ref: epinio-dev
-        ref: epinio-standalone-v1.2.0.0.0.1 
+        ref: epinio-dev
         path: dashboard
 
     - uses: actions/setup-node@v2

--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install & Build
       run: |
         cd dashboard
-        RANCHER_ENV=epinio EXCLUDES_PKG=rancher-components .github/workflows/scripts/build-dashboard.sh
+        EXCLUDES_PKG=harvester,rancher-components EXCLUDES_NUXT_PLUGINS=plugins/version,plugins/plugin .github/workflows/scripts/build-dashboard.sh
 
     - name: Upload Build
       uses: actions/upload-artifact@v2

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -54,10 +54,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: rancher/dashboard
-          # Momentarily freezing latest version until epinio-dev is stable
-          # https://github.com/epinio/epinio-end-to-end-tests/issues/247
-          # ref: epinio-dev
-          ref: epinio-standalone-v1.2.0.0.0.1
+          ref: epinio-dev
           path: dashboard
 
       - name: Checkout Epinio UI-backend repository


### PR DESCRIPTION
Bringing back latest `epinio-dev` after freezing it to `epinio-standalone-v1.2.0.0.0.1` [here](https://github.com/epinio/epinio-end-to-end-tests/issues/247#issuecomment-1282536556)

Basically excluded some env vars to prevent oom issues.

Tested on this CI ([Build Latest-STD-UI #1047](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3329677383/jobs/5507195439#step:5:11)) and working:
![image (2)](https://user-images.githubusercontent.com/37271841/198051393-81b0fd07-6ffa-410e-9987-6f912deef1dd.png)
