### PR TITLE
fixing missing env var RANCHER_ENV=epinio

### DIFF
--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install & Build
       run: |
         cd dashboard
-        EXCLUDES_PKG=harvester,rancher-components EXCLUDES_NUXT_PLUGINS=plugins/version,plugins/plugin .github/workflows/scripts/build-dashboard.sh
+        RANCHER_ENV=epinio EXCLUDES_PKG=harvester,rancher-components EXCLUDES_NUXT_PLUGINS=plugins/version,plugins/plugin .github/workflows/scripts/build-dashboard.sh
 
     - name: Upload Build
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Adding missing env var `RANCHER_ENV=epinio` after [this](https://github.com/epinio/epinio-end-to-end-tests/pull/261) fix  to the construction of latest epinio ui image

Tests:

Creation of [Build Latest-STD-UI #1050](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3330563308) passing::
 ![image](https://user-images.githubusercontent.com/37271841/198079961-27023875-15fb-45f8-ad52-f63420ebf536.png)


UI test [STD-UI-Latest-Firefox #164](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3330656436/jobs/5509422750) passing
![image](https://user-images.githubusercontent.com/37271841/198079833-34ea424b-da16-4347-ace8-7303336c25fe.png)
