### PR TITLE
Updating actions for qa image

### DIFF
--- a/.github/workflows/build_latest_epinioUI.yml
+++ b/.github/workflows/build_latest_epinioUI.yml
@@ -17,18 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout end-to-end-tests repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: epinio-end-to-end-tests
     
     - name: Checkout dashboard repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: rancher/dashboard
         ref: epinio-dev
         path: dashboard
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '14.x'
 
@@ -38,7 +38,7 @@ jobs:
         RANCHER_ENV=epinio EXCLUDES_PKG=harvester,rancher-components EXCLUDES_NUXT_PLUGINS=plugins/version,plugins/plugin .github/workflows/scripts/build-dashboard.sh
 
     - name: Upload Build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: dashboard/${{ env.RELEASE_DIR}}/${{ env.ARTIFACT_NAME }}*
         name: ${{ env.ARTIFACT_NAME }}
@@ -46,7 +46,7 @@ jobs:
 
     # BUILD LATEST UI-BACKEND
     - name: Checkout dashboard repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: epinio/ui-backend
         path: ui-backend
@@ -61,15 +61,15 @@ jobs:
         git tag -a v99.0.0 -m "Fake tag for QA" --force
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.17'
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.EPINIO_DOCKER_USER }}
         password: ${{ secrets.EPINIO_DOCKER_PASSWORD }}
@@ -88,7 +88,7 @@ jobs:
         cp ../epinio-end-to-end-tests/.goreleaser-dashboard-qa.yml .
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v3
       with:
         distribution: goreleaser
         version: latest


### PR DESCRIPTION
Related to https://github.com/epinio/epinio-end-to-end-tests/issues/263

Bump of Github actions.
Fixes annotation problems.

Proof:

Before: [Build Latest-STD-UI #1056](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3336099686)
After: [Build Latest-STD-UI #1057](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3336405942)

![image](https://user-images.githubusercontent.com/37271841/198270505-6617c9c1-a156-4308-8800-0f61ae5da1c4.png)

Checked this update does not affect the test here: [Rancher-UI-2-Firefox #336](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3336496926)
