### PR TITLE
Cypress/bump to ghactionv4

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -114,7 +114,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: ${{ inputs.browser }}
-          headless: true
+          # headless: true
           spec: |
             cypress/e2e/unit_tests/first_connexion.spec.ts
             cypress/e2e/unit_tests/${{ inputs.cypress_install_test }}
@@ -215,7 +215,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: ${{ inputs.browser }}
-          headless: true
+          # headless: true
           spec: |
             cypress/e2e/unit_tests/${{ inputs.cypress_test }}
           config-file: cypress.config.ts
@@ -275,7 +275,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: ${{ inputs.browser }}
-          headless: true
+          # headless: true
           spec: |
             cypress/e2e/unit_tests/uninstall.spec.ts
           config-file: cypress.config.ts

--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
 
       - name: Cypress run
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           browser: ${{ inputs.browser }}
           headless: true
@@ -212,7 +212,7 @@ jobs:
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
       - name: Cypress run
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           browser: ${{ inputs.browser }}
           headless: true
@@ -272,7 +272,7 @@ jobs:
     steps:
 
       - name: Cypress run
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           browser: ${{ inputs.browser }}
           headless: true


### PR DESCRIPTION
Bumping Github action on `cypress-io/github-action@v3` to `cypress-io/github-action@v4` `Cypress run` step on Rancher tests.
In the process of doing so this warning appeared, so I removed also the flag `headless: true` :

```
Warning: Unexpected input(s) 'headless', valid inputs are ['record', 'config', 'config-file', 'env', 'browser', 'command', 'start', 'start-windows', 'build', 'install', 'install-command', 'runTests', 'wait-on', 'wait-on-timeout', 'parallel', 'group', 'tag', 'working-directory', 'headed', 'spec', 'project', 'command-prefix', 'ci-build-id', 'cache-key', 'quiet', 'component']
```

Result: [Rancher-UI-1-Chrome #358](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3419441306) flag removed
![image](https://user-images.githubusercontent.com/37271841/200587112-09f72382-b19d-4338-93c0-1bc8605371ce.png)

