### PR TITLE
Assign regcred secret to default sa

### DIFF
--- a/scripts/create_docker_secret.sh
+++ b/scripts/create_docker_secret.sh
@@ -7,3 +7,5 @@ kubectl create secret docker-registry regcred \
   --docker-server https://index.docker.io/v1/ \
   --docker-username $EXT_REG_USER \
   --docker-password $EXT_REG_PASSWORD
+# Use the docker hub credentials in default sa
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'


### PR DESCRIPTION
This will enable using docker hub credentials for pulling images from k8s.

The original code was not complete, the credentials were created as `regcred` secret but not assigned to `default` serviceAccount.