### PR TITLE
Cypress/adapt wordpress service test

### DIFF
--- a/cypress/fixtures/read_from_worpress_file.txt
+++ b/cypress/fixtures/read_from_worpress_file.txt
@@ -1,4 +1,5 @@
 BP_PHP_VERSION=8.0.x
 BP_PHP_SERVER=nginx
 BP_PHP_WEB_DIR=wordpress 
-CONFIG_NAME=x8e5ee833a0f2faebaf5c4171baca-mysql
+DB_HOST=x8e5ee833a0f2faebaf5c4171baca-mysql
+SERVICE_NAME=mycustom-service

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -282,8 +282,10 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
     cy.get('.no-resize').eq(1).should('have.value', 'nginx');
     cy.get('.key > input').eq(2).should('have.value', 'BP_PHP_WEB_DIR');
     cy.get('.no-resize').eq(2).should('have.value', 'wordpress ');
-    cy.get('.key > input').eq(3).should('have.value', 'CONFIG_NAME');
+    cy.get('.key > input').eq(3).should('have.value', 'DB_HOST');
     cy.get('.no-resize').eq(3).should('have.value', 'x8e5ee833a0f2faebaf5c4171baca-mysql');
+    cy.get('.key > input').eq(4).should('have.value', 'SERVICE_NAME');
+    cy.get('.no-resize').eq(4).should('have.value', 'mycustom-service');
   }
 
   if (addVar === 'go_example') {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -186,7 +186,6 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
     cy.wait(5000)
     cy.get('.labeled-select.hoverable').contains('Source Type', {timeout: 10000}).should('be.visible').click( {force : true} );
     cy.wait(1000)
-    cy.screenshot('SrcType Dropown after opening')
     cy.contains(sourceType, {timeout: 10000}).should('be.visible').click({force: true});
     switch (sourceType) {
       case 'Container Image':
@@ -197,9 +196,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
         cy.typeValue({label: 'Branch', value: 'main'}); 
         break;
       case 'Archive':
-        cy.screenshot('SrcType Dropown opened BEFORE selecting ARCHIVE')
         cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});   
-        cy.screenshot('SrcType Dropown opened AFTER selecting ARCHIVE')
         break; 
       case 'GitHub':
         cy.get('.labeled-input.edit.has-tooltip',{timeout:5000}).contains('label', 'Username / Organization').should('be.visible')


### PR DESCRIPTION
Adapting application test `Create mysql service, bind it to a Wordpress app and push it` after changes in Wordpress repo here: https://github.com/epinio/example-wordpress/pull/9

Done:
- Removed var `CONFIG_NAME=x8e5ee833a0f2faebaf5c4171baca-mysql`
- Added var `DB_HOST=x8e5ee833a0f2faebaf5c4171baca-mysql` and `SERVICE_NAME=mycustom-service`
- Added check options in UI for those env vars

Extra:
- Removed screenshots in source type dropdowns


Result OK in CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3532099623/jobs/5926039018#step:14:63
![image](https://user-images.githubusercontent.com/37271841/203564529-620dc4e3-de86-4155-b997-923c444d4735.png)


