### PR TITLE
Patch epinio-ui in rancher tests

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -192,6 +192,12 @@ jobs:
           make build
           make patch-epinio-deployment
 
+      - name: Patch epinio-ui with latest QA image
+        env:
+          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+        run: |
+          make patch-epinio-ui
+
   # Use a second Cypress container to run all Epinio's tests
   cypress-epinio-tests:
     needs:


### PR DESCRIPTION
After changing CLI  binaries (arm64-> x86_64) by https://github.com/epinio/epinio-end-to-end-tests/pull/274 our Rancher-UI tests started to fail. I noticed that we don't do `epinio-ui` patching for rancher tests, this PR will address that.

Test run passed https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3582043482