### PR TITLE
Adapt binary link test to epinio server version

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -59,42 +59,47 @@ describe('Menu testing', () => {
         cy.visit('/epinio/about');
       });
 
-      // Check all links work and match the expected version
+      // The following should happen only if server version = 6 chars (v2.0.0 for instance)
+      cy.log(`Server version is (${version.length} characters) long.`)
+      if (version.length < 7) {
 
-      // Verify amount of binaries in the page
-      cy.get('tr.link > td > a').should('have.length', 3);
-      const binOsNames = ['darwin-x86_64', 'linux-x86_64', 'windows-x86_64.zip'];
+        // Check all links work and match the expected version
 
-      for (let i = 0; i < binOsNames.length; i++) {
+        // Verify amount of binaries in the page
+        cy.get('tr.link > td > a').should('have.length', 3);
+        const binOsNames = ['darwin-x86_64', 'linux-x86_64', 'windows-x86_64.zip'];
 
-        // Verify binaries names and version match the one in the page
-        cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
-          .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
-      }
+        for (let i = 0; i < binOsNames.length; i++) {
 
-      // Downloading using wget to issues with Github when clicking
-      // Scoping download solely to Linux amd
-      cy.exec('mkdir -p cypress/downloads');
-      cy.exec(`wget -qS  https://github.com/epinio/epinio/releases/download/${version}/epinio-linux-x86_64 -O cypress/downloads/epinio-linux-x86_64`, { failOnNonZeroExit: false }).then((result) => {
-        if (result.code != 0) {
-          cy.task('log', '### ERROR: Could not download binary. Probably an error on Github ###');
+          // Verify binaries names and version match the one in the page
+          cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
+            .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
         }
-        cy.task('log', '### Stderr for download binary command starts here.');
-        cy.task('log', result.stderr);
-      });
-
-      // Check link "See all packages" and visit binary page
-      // Check version number in binary page matches the one in Epinio
-      cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').as('href_repo').then(() => {
-        cy.get('@href_repo').should('eq', `https://github.com/epinio/epinio/releases/tag/${version}`);
-        // Giving a bit of time beween latest time hitting github and now
-        cy.wait(2000);
-        cy.origin('https://github.com', { args: { version } }, ({ version }) => {
-          cy.visit(`/epinio/epinio/releases/tag/${version}`, { timeout: 15000 });
-          cy.get('.d-inline.mr-3', { timeout: 15000 }).contains(`${version}`).should('be.visible');
-          cy.screenshot(`epinio-bin-repo-${version}`, { timeout: 15000 });
+        // Downloading using wget to issues with Github when clicking
+        // Scoping download solely to Linux amd
+        cy.exec('mkdir -p cypress/downloads');
+        cy.exec(`wget -qS  https://github.com/epinio/epinio/releases/download/${version}/epinio-linux-x86_64 -O cypress/downloads/epinio-linux-x86_64`, { failOnNonZeroExit: false }).then((result) => {
+          if (result.code != 0) {
+            cy.task('log', '### ERROR: Could not download binary. Probably an error on Github ###');
+          }
+          cy.task('log', '### Stderr for download binary command starts here.');
+          cy.task('log', result.stderr);
         });
-      });
+
+        // Check link "See all packages" and visit binary page
+        // Check version number in binary page matches the one in Epinio
+        cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').as('href_repo').then(() => {
+          cy.get('@href_repo').should('eq', `https://github.com/epinio/epinio/releases/tag/${version}`);
+          // Giving a bit of time beween latest time hitting github and now
+          cy.wait(2000);
+          cy.origin('https://github.com', { args: { version } }, ({ version }) => {
+            cy.visit(`/epinio/epinio/releases/tag/${version}`, { timeout: 15000 });
+            cy.get('.d-inline.mr-3', { timeout: 15000 }).contains(`${version}`).should('be.visible');
+            cy.screenshot(`epinio-bin-repo-${version}`, { timeout: 15000 });
+          });
+        });
+      }
+      else {cy.log(`Server version is too long (${version.length} characters) so binary download will not work and it is currently disabled.`)}
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/epinio/epinio-end-to-end-tests/issues/277

Implementation:
- Added a rule to skip downloading or checking links if length of characters in  version number in links page is >=7 characters (ie: `v1.5.1-25-ga9b168ab` and keep doing it if still less (ie: `v1.5.1`)


Results when version >= 7 characters:
![2022-12-05_17-21](https://user-images.githubusercontent.com/37271841/205690462-42193163-588c-454d-a02b-a88d4cb250d0.png)


Results when version <7 characters (binaries are downloaded):
![2022-12-05_17-15](https://user-images.githubusercontent.com/37271841/205690507-d5cf473e-b7fb-4fb1-9d05-ffde315dd26b.png)


