### PR TITLE
PR: Test namespaces filter

### DIFF
--- a/cypress/e2e/unit_tests/namespaces.spec.ts
+++ b/cypress/e2e/unit_tests/namespaces.spec.ts
@@ -20,7 +20,7 @@ describe('Namespaces testing', () => {
   });
 
   if (Cypress.env('ui') != 'epinio-rancher' || Cypress.env('ui') != 'rancher') {
-  it('Test namespace filter with 3 namespaces, 3 apps and 3 configurations', () => {
+  it('Test namespace filter with 3 namespaces, 2 apps and 2 configurations', () => {
     cy.runNamespacesTest('namespaceFilter');
   })};
 });

--- a/cypress/e2e/unit_tests/namespaces.spec.ts
+++ b/cypress/e2e/unit_tests/namespaces.spec.ts
@@ -19,7 +19,8 @@ describe('Namespaces testing', () => {
     cy.runNamespacesTest('newNamespace');
   });
 
-  it.only('Test namespace filter with 3 namespaces, 3 apps and 3 configurations', () => {
+  if (Cypress.env('ui') != 'epinio-rancher' || Cypress.env('ui') != 'rancher') {
+  it('Test namespace filter with 3 namespaces, 3 apps and 3 configurations', () => {
     cy.runNamespacesTest('namespaceFilter');
-  });
+  })};
 });

--- a/cypress/e2e/unit_tests/namespaces.spec.ts
+++ b/cypress/e2e/unit_tests/namespaces.spec.ts
@@ -18,4 +18,8 @@ describe('Namespaces testing', () => {
   it('Push and check an application into the created namespace', () => {
     cy.runNamespacesTest('newNamespace');
   });
+
+  it.only('Test namespace filter with 3 namespaces, 3 apps and 3 configurations', () => {
+    cy.runNamespacesTest('namespaceFilter');
+  });
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,11 +14,11 @@ declare global {
       clickEpinioMenu(label: string,): Chainable<Element>;
       clickClusterMenu(listLabel: string[],): Chainable<Element>;
       confirmDelete(namespace?: string,): Chainable<Element>;
-      checkStageStatus(numIndex: number, sourceType: string, timeout?: number, status?: string,): Chainable<Element>;
+      checkStageStatus(numIndex: number, sourceType: string, timeout?: number, status?: string, appName?: string,): Chainable<Element>;
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
-      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string): Chainable<Element>;
+      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string, namespace?: string,): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string ): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;
@@ -28,13 +28,10 @@ declare global {
       downloadManifest(appName: string): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
-
-      // WIP
-      openNamespacesFilter(location: string, namespace?: string, appName?: string, configurationName?: string): Chainable<Element>;
-      filterNamespacesAndCheck(namespace: string, elemInNamespaceName: string): Chainable<Element>;
-      checkNumberFilteredNamespacesAndElements(expectedNumFilteredNamespaces: number, expectedNumElemInNamespaces: number ): Chainable<Element>;
-      //END OF WIP
-
+      openNamespacesFilter(location: string, namespace?: string, appName?: string, configurationName?: string,): Chainable<Element>;
+      filterNamespacesAndCheck(namespace: string, elemInNamespaceName?: string, filterOut?: boolean,): Chainable<Element>;
+      checkOutcomeFilteredNamespaces(expectedNumFilteredNamespaces: number, expectedNumElemInNamespaces: number, expectedNameElementInNamespaces?:string,): Chainable<Element>;
+      selectNamespaceinComboBox(namespace: string,): Chainable<Element>;    
       createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       editConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -28,6 +28,13 @@ declare global {
       downloadManifest(appName: string): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
+
+      // WIP
+      openNamespacesFilter(location: string, namespace?: string, appName?: string, configurationName?: string): Chainable<Element>;
+      filterNamespacesAndCheck(namespace: string, elemInNamespaceName: string): Chainable<Element>;
+      checkNumberFilteredNamespacesAndElements(expectedNumFilteredNamespaces: number, expectedNumElemInNamespaces: number ): Chainable<Element>;
+      //END OF WIP
+
       createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       editConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -538,6 +538,51 @@ Cypress.Commands.add('deleteNamespace', ({namespace, appName}) => {
     cy.contains(appName).should('not.exist');
   }
 });
+/////////////////////////////  WIP /////////////////////////////////////////////////
+Cypress.Commands.add('openNamespacesFilter', ({location}) => {
+  // cy.clickEpinioMenu(location);
+  // cy.reload()
+  cy.clickEpinioMenu("Applications");
+
+  cy.wait(15000)
+  // cy.get(".sortable-table.top-divider > tbody> tr.main-row", {timeout: 10000}).should('be.visible')
+  // cy.contains("Loading", {timeout: 10000}).should("not.be.visible")
+  // Open namespace filter dropdown
+  cy.get('.top > .ns-filter').click({force : true})
+
+  // Confirm it is opened
+  cy.get('i[class="icon icon-close"]', {timeout: 5000}).should('be.visible')
+});
+
+Cypress.Commands.add('filterNamespacesAndCheck', ({namespace, elemInNamespaceName}) => {
+  // Select particular namespace in filter
+  cy.get('.ns-item').contains(namespace).click().then(()=>
+    cy.get('.icon.icon-checkmark').should('be.visible')
+  )
+
+  // Check chip is added on top of filter
+  cy.get('.ns-value').contains(namespace).should('be.visible')
+  
+  // Check element associated to namespace (app, config,...) is displayed
+  cy.get(".sortable-table.top-divider > tbody> tr.main-row")
+  .find('td')
+  .contains(elemInNamespaceName)
+  .should('have.length', 1)
+});
+
+Cypress.Commands.add('checkNumberFilteredNamespacesAndElements', ({expectedNumFilteredNamespaces, expectedNumElemInNamespaces}) => {
+ 
+  // Check chip is added on top of filter
+  cy.get('div.ns-value').should('have.length', expectedNumFilteredNamespaces)
+  
+  // Check element associated to namespace (app, config,...) is displayed
+  cy.get(".sortable-table.top-divider > tbody> tr.main-row")
+  .should('have.length', expectedNumElemInNamespaces)
+});
+
+
+
+/////////////////////////////  WIP /////////////////////////////////////////////////
 
 // Configurations functions
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -47,13 +47,13 @@ Cypress.Commands.add('byLabel', (label) => {
 
 // Search button by label
 Cypress.Commands.add('clickButton', (label) => {
-  cy.get('.btn').contains(label).click();
+  cy.get('.btn', {timeout: 30000}).contains(label).click();
 });
 
 // Ensure that we are in the desired menu
 Cypress.Commands.add('clickEpinioMenu', (label) => {
-  cy.get('.header').contains('Advanced').click();
-  cy.get('.label').contains(label).click();
+  cy.get('.header').contains('Advanced').click( {force : true} );
+  cy.get('.label').contains(label).click( {force : true} );
   cy.location('pathname').should('include', '/' + label.toLocaleLowerCase());
   // This will check application menu regardles if it has namespaces
   cy.get("body").then(($body) => {
@@ -93,11 +93,11 @@ Cypress.Commands.add('deleteAll', (label) => {
 });
 
 // Check the status of the running stage
-Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, status='Success'}) => {
+Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, status='Success', appName="testapp"}) => {
   var getScope = ':nth-child(' + numIndex + ') > .col-badge-state-formatter > .status > .badge';
   if (sourceType == 'Container Image') {
     if (numIndex === 2) {
-      cy.get('.tab-label', {timeout: 100000}).should('contain', 'testapp - App Logs');
+      cy.get('.tab-label', {timeout: 100000}).should('contain', `${appName} - App Logs`);
       cy.contains('Command line: \'httpd -D FOREGROUND\'', {timeout: timeout});
       cy.get('.tab > .closer').click(); 
     }
@@ -117,7 +117,7 @@ Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, s
         cy.get('.tab > .closer').click();
       }      
   }
-  cy.get(getScope, {timeout: timeout}).contains(status).should('be.visible');
+  cy.get(getScope, {timeout: 20000}).contains(status).should('be.visible');
 });
 
 // Insert a value in a field *BUT* force a clear before!
@@ -174,7 +174,7 @@ Cypress.Commands.add('getDetail', ({name, type, namespace='workspace'}) => {
 // Application functions
 
 // Create an Epinio application
-Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPaketoImage, customApplicationChart, route, addVar, instanceNum=1, configurationName, shouldBeDisabled, manifestName, serviceName, catalogType}) => {
+Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPaketoImage, customApplicationChart, route, addVar, instanceNum=1, configurationName, shouldBeDisabled, manifestName, serviceName, catalogType, namespace='workspace'}) => {
   var envFile = 'read_from_file.env';  // File to use for the "Read from File" test
 
   cy.clickEpinioMenu('Applications');
@@ -247,9 +247,14 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
   }
 
   // Define application's name
-  if (appName){
-  cy.typeValue({label: 'Name', value: appName});
-}
+  if (appName) {
+    cy.typeValue({ label: 'Name', value: appName });
+  }
+
+  // Select other namespace aside from default
+  if (namespace != 'workspace'){
+    cy.selectNamespaceinComboBox({namespace});
+    }
 
   // Change default route if needed
   if (route) {
@@ -316,7 +321,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
 
   // Check that each steps are succesfully done
   cy.checkStageStatus({numIndex: 1});
-  cy.checkStageStatus({numIndex: 2, timeout: 240000, sourceType});
+  cy.checkStageStatus({numIndex: 2, timeout: 240000, sourceType, appName});
   if (sourceType !== 'Container Image') {
     cy.checkStageStatus({numIndex: 3, timeout: 240000, sourceType});
     cy.checkStageStatus({numIndex: 4, timeout: 240000});
@@ -538,51 +543,78 @@ Cypress.Commands.add('deleteNamespace', ({namespace, appName}) => {
     cy.contains(appName).should('not.exist');
   }
 });
-/////////////////////////////  WIP /////////////////////////////////////////////////
-Cypress.Commands.add('openNamespacesFilter', ({location}) => {
-  // cy.clickEpinioMenu(location);
-  // cy.reload()
-  cy.clickEpinioMenu("Applications");
 
-  cy.wait(15000)
-  // cy.get(".sortable-table.top-divider > tbody> tr.main-row", {timeout: 10000}).should('be.visible')
-  // cy.contains("Loading", {timeout: 10000}).should("not.be.visible")
+Cypress.Commands.add('openNamespacesFilter', ({location}) => {
+  cy.clickEpinioMenu(location);
+  cy.contains('Namespace:', {timeout: 55000}).should('be.visible');
+
   // Open namespace filter dropdown
-  cy.get('.top > .ns-filter').click({force : true})
+  cy.get('.top > .ns-filter').click({force : true});
 
   // Confirm it is opened
   cy.get('i[class="icon icon-close"]', {timeout: 5000}).should('be.visible')
 });
 
-Cypress.Commands.add('filterNamespacesAndCheck', ({namespace, elemInNamespaceName}) => {
-  // Select particular namespace in filter
-  cy.get('.ns-item').contains(namespace).click().then(()=>
-    cy.get('.icon.icon-checkmark').should('be.visible')
-  )
+Cypress.Commands.add('filterNamespacesAndCheck', ({ namespace, elemInNamespaceName, filterOut=false }) => {
 
-  // Check chip is added on top of filter
-  cy.get('.ns-value').contains(namespace).should('be.visible')
-  
-  // Check element associated to namespace (app, config,...) is displayed
-  cy.get(".sortable-table.top-divider > tbody> tr.main-row")
-  .find('td')
-  .contains(elemInNamespaceName)
-  .should('have.length', 1)
+  if (filterOut === true) {
+    // Select particular namespace in filter
+    cy.get('.ns-item').contains(namespace).click();    
+
+    // Check chip is not displayed on top of filter
+    cy.get('[data-testid="namespaces-dropdown"]').contains(namespace).should('not.exist');
+    
+    if (elemInNamespaceName) {
+    // Check element associated to namespace (app, config,...) is not displayed
+    cy.get(".sortable-table.top-divider > tbody> tr.main-row")
+      .find('td')
+      .contains(elemInNamespaceName)
+      .should('not.exist');
+    }
+  }
+
+  else if (filterOut === false) {
+    // Select particular namespace in filter
+    cy.get('.ns-item').contains(namespace).click().then(() =>
+      cy.get('.icon.icon-checkmark').should('be.visible'));
+
+    // Check chip is added on top of filter
+    cy.get('.ns-value').contains(namespace).should('be.visible');
+
+    // Check element associated to namespace (app, config,...) is displayed
+    cy.get(".sortable-table.top-divider > tbody> tr.main-row")
+      .find('td')
+      .contains(elemInNamespaceName)
+      .should('have.length', 1);
+  }
 });
 
-Cypress.Commands.add('checkNumberFilteredNamespacesAndElements', ({expectedNumFilteredNamespaces, expectedNumElemInNamespaces}) => {
+Cypress.Commands.add('checkOutcomeFilteredNamespaces', ({expectedNumFilteredNamespaces, expectedNumElemInNamespaces, expectedNameElementInNamespaces}) => {
  
   // Check chip is added on top of filter
   cy.get('div.ns-value').should('have.length', expectedNumFilteredNamespaces)
   
+  // If 0 namespaces are filtered, check All namespaces is selected
+  if(expectedNumFilteredNamespaces = 0) {
+    cy.get('#all.ns-selected').contains('All Namespaces').should('be.selected');
+  }
+
   // Check element associated to namespace (app, config,...) is displayed
   cy.get(".sortable-table.top-divider > tbody> tr.main-row")
   .should('have.length', expectedNumElemInNamespaces)
+
+  // Check element displayed (app,config, etc) if specified
+  if(expectedNameElementInNamespaces) {
+  cy.get(".sortable-table.top-divider > tbody> tr.main-row").contains(expectedNameElementInNamespaces).should('be.visible');
+  }
+
 });
 
 
-
-/////////////////////////////  WIP /////////////////////////////////////////////////
+Cypress.Commands.add('selectNamespaceinComboBox', ({namespace}) => {
+  cy.get('span.vs__selected',{timeout: 25000}).should('be.visible').click({ force: true });
+  cy.get('ul.vs__dropdown-menu > li').contains(namespace).click({ force: true });
+});
 
 // Configurations functions
 
@@ -592,6 +624,11 @@ Cypress.Commands.add('createConfiguration', ({configurationName, fromFile, names
 
   cy.clickEpinioMenu('Configurations');
   cy.clickButton('Create');
+
+  // Select other namespace aside from default
+  if (namespace != 'workspace'){
+  cy.selectNamespaceinComboBox({namespace})
+  }
 
   // Name of the configuration
   cy.typeValue({label: 'Name', value: configurationName});
@@ -614,7 +651,7 @@ Cypress.Commands.add('createConfiguration', ({configurationName, fromFile, names
   cy.clickButton('Create');
 
   // Check that the configuration has effectively been created
-  cy.contains(configurationName).should('be.visible');
+  cy.contains(configurationName, {timeout: 20000}).should('be.visible');
   // Give some time to the configuration to be ready
   cy.wait(1000);
 });

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -159,20 +159,35 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
 
     case 'namespaceFilter':
       // Preparation
-      // cy.createNamespace('ns-1');
-      // cy.createNamespace('ns-2');
-      // cy.createConfiguration({configurationName: "config-1"});
-      // cy.createConfiguration({configurationName: "config-2"});
-      // cy.createApp({appName: "app-1"});
-      // cy.createApp({appName: "app-2"});
-      //
-      // cy.openNamespacesFilter({location: "Applications"})
-      cy.openNamespacesFilter("Applications")
-      cy.filterNamespacesAndCheck({namespace: "ns-1", elemInNamespaceName: "testapp1"})
-      cy.filterNamespacesAndCheck({namespace: "ns-2", elemInNamespaceName: "testapp2"})
+      cy.createNamespace('ns-1');
+      cy.createNamespace('ns-2');
+
+      cy.createConfiguration({configurationName: "config-1", namespace: "ns-1"});
+      cy.createConfiguration({configurationName: "config-2", namespace: "ns-2"});
+     
+      cy.createApp({appName: "testapp-1", namespace: "ns-1", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
+      cy.createApp({appName: "testapp-2", namespace: "ns-2", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
+        
+      cy.openNamespacesFilter({location: "Applications"})
+      cy.filterNamespacesAndCheck({namespace: "ns-1", elemInNamespaceName: "testapp-1", filterOut: false})
+      cy.filterNamespacesAndCheck({namespace: "ns-2", elemInNamespaceName: "testapp-2", filterOut: false})
+ 
       // Check 2 ns filters are acually selected
-      cy.checkNumberFilteredNamespacesAndElements({expectedNumFilteredNamespaces: 2, expectedNumElemInNamespaces: 2 })
-      cy.clickEpinioMenu("configurations")
+      cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 2, expectedNumElemInNamespaces: 2})
+
+      // Deselect ns-2 and check it is filtered out and not displayed
+      cy.filterNamespacesAndCheck({namespace: "ns-2", elemInNamespaceName: "testapp-2", filterOut: true})
+      cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 1, expectedNumElemInNamespaces: 1, expectedNameElementInNamespaces: "testapp-1"})
+
+      // With previous selection, go to config and check filter is still applied
+      cy.clickEpinioMenu("Configurations")
+      cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 1, expectedNumElemInNamespaces: 1, expectedNameElementInNamespaces: "config-1"})
+    
+      // Deselect ns-1 and check 3 namespaces and 2 apps appear
+      cy.filterNamespacesAndCheck({namespace: "ns-1", filterOut: true})
+      cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 0, expectedNumElemInNamespaces: 2, expectedNameElementInNamespaces: "config-1"})
+      cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 0, expectedNumElemInNamespaces: 2, expectedNameElementInNamespaces: "config-2"})
+
       break;
   }
 });

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -161,13 +161,12 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       // Preparation
       cy.createNamespace('ns-1');
       cy.createNamespace('ns-2');
-
       cy.createConfiguration({configurationName: "config-1", namespace: "ns-1"});
-      cy.createConfiguration({configurationName: "config-2", namespace: "ns-2"});
-     
+      cy.createConfiguration({configurationName: "config-2", namespace: "ns-2"});    
       cy.createApp({appName: "testapp-1", namespace: "ns-1", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
       cy.createApp({appName: "testapp-2", namespace: "ns-2", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
-        
+      
+      // Go to Appplications and filter 2 namespaces in namespace filter
       cy.openNamespacesFilter({location: "Applications"})
       cy.filterNamespacesAndCheck({namespace: "ns-1", elemInNamespaceName: "testapp-1", filterOut: false})
       cy.filterNamespacesAndCheck({namespace: "ns-2", elemInNamespaceName: "testapp-2", filterOut: false})
@@ -187,7 +186,7 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       cy.filterNamespacesAndCheck({namespace: "ns-1", filterOut: true})
       cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 0, expectedNumElemInNamespaces: 2, expectedNameElementInNamespaces: "config-1"})
       cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 0, expectedNumElemInNamespaces: 2, expectedNameElementInNamespaces: "config-2"})
-
       break;
+      
   }
 });

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import cypress from 'cypress';
 import { Epinio } from '~/cypress/support/epinio';
 import './functions';
@@ -154,6 +155,24 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
 
       // Delete the namespace
       cy.deleteNamespace({namespace: namespace, appName: appName});
+      break;
+
+    case 'namespaceFilter':
+      // Preparation
+      // cy.createNamespace('ns-1');
+      // cy.createNamespace('ns-2');
+      // cy.createConfiguration({configurationName: "config-1"});
+      // cy.createConfiguration({configurationName: "config-2"});
+      // cy.createApp({appName: "app-1"});
+      // cy.createApp({appName: "app-2"});
+      //
+      // cy.openNamespacesFilter({location: "Applications"})
+      cy.openNamespacesFilter("Applications")
+      cy.filterNamespacesAndCheck({namespace: "ns-1", elemInNamespaceName: "testapp1"})
+      cy.filterNamespacesAndCheck({namespace: "ns-2", elemInNamespaceName: "testapp2"})
+      // Check 2 ns filters are acually selected
+      cy.checkNumberFilteredNamespacesAndElements({expectedNumFilteredNamespaces: 2, expectedNumElemInNamespaces: 2 })
+      cy.clickEpinioMenu("configurations")
       break;
   }
 });


### PR DESCRIPTION
Implements https://github.com/epinio/epinio-end-to-end-tests/issues/213

### Summary of test steps
- Creates 2 new namespaces, 2 configurations and 2 applications (1 per new namespace)
- Within Applications:
  -  Select 2 namespaces from filter and check results
  -  Deselects 1 namespace and check results
- With 1 selected, goes to Configurations and: 
  - Checks selection is maintained
  - Deselects remaining namespace and check results
  - Check all namespaces are selected when none is deselected

#### Video for namespace filter steps:

https://user-images.githubusercontent.com/37271841/206219883-d471c893-6b7a-4a5c-b1ae-a55c71d69573.mov


  
#### Test results locally:
![testNameFilter](https://user-images.githubusercontent.com/37271841/206220170-e47ab826-196e-4ca2-bdc8-712b3418bef3.png)

