### PR TITLE
Updating  cypress-io/github-action to v5

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -105,7 +105,7 @@ jobs:
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ github.event.inputs.docker_options }}
     steps:
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: ${{ github.event.inputs.browser }}
           # headless: true
@@ -164,7 +164,7 @@ jobs:
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: ${{ github.event.inputs.browser }}
           # headless: true
@@ -222,7 +222,7 @@ jobs:
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         env:
           EXPERIMENTAL_CHART_BRANCH: ${{ github.event.inputs.experimental_chart_branch }}
         with:

--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
 
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: ${{ inputs.browser }}
           # headless: true
@@ -218,7 +218,7 @@ jobs:
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: ${{ inputs.browser }}
           # headless: true
@@ -278,7 +278,7 @@ jobs:
     steps:
 
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           browser: ${{ inputs.browser }}
           # headless: true


### PR DESCRIPTION
Updating dependency `cypress-io/github-action` to `v5`
Successful test here: [STD-UI-Latest-Firefox #284](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/3910607127/jobs/6682999823)
