### PR TITLE
Adding k3s version as dispatch

### DIFF
--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   # Variables to set when calling this reusable workflow
     inputs:
+      k3s_version:
+        description: k3s version
+        required: true
+        type: string
+        default: v1.24.6+k3s1
       browser:
         description: Browser where the test will run
         required: true
@@ -95,7 +100,7 @@ jobs:
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
-          K3S_VERSION: v1.24.6+k3s1
+          K3S_VERSION: ${{ inputs.k3s_version }}
           EXT_REG: ${{ inputs.ext_reg }}
           S3: ${{ inputs.s3 }}
           EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}


### PR DESCRIPTION
Adding k3s version dispatch to the `master_std_ui_experimental.yml` to customize different Kubernetes versions directly from Github Actions UI

Current default: `1.24.6+k3s1`

Tested against `v1.25.6+k3s1`

Working as expected: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4025744145/jobs/6919360470#step:12:96

![image](https://user-images.githubusercontent.com/37271841/215122927-2bdc76fd-5b62-47d5-8dd2-f241c4dfa070.png) ![image](https://user-images.githubusercontent.com/37271841/215123003-576cbae2-cb73-4c8a-9d9b-9480e41025f8.png)

