### PR TITLE
[Cypress] Adding kubernetes version dispatch for Rancher Dashboard experimental

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -9,6 +9,11 @@ on:
           description: Add branch for experimental Epinio Charts
           required: false
           default: ''
+        k3s_version:
+          description: k3s version
+          required: true
+          type: string
+          default: v1.24.6+k3s1
         browser:
           description: Web browser to test
           required: true
@@ -60,7 +65,7 @@ jobs:
           DASHBOARD_VERSION: epinio-dev
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.7.0
-          K3S_VERSION: v1.24.6+k3s1
+          K3S_VERSION: ${{ inputs.k3s_version }}
           EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}
           EXT_REG_PASSWORD: ${{ secrets.EPINIO_DOCKER_PASSWORD }}
           S3_KEY_ID: ${{ secrets.s3_key_id }}


### PR DESCRIPTION
### Summary
Adding Github action dispatch of to select `k3s` version for Master Rancher UI EXPERIMENTAL workflow

![image](https://user-images.githubusercontent.com/37271841/216939632-fb04a5ee-bb4b-4874-a074-5589b366399c.png)

---

### Tests runs
- k3s default version `v1.24.6+k3s1` passing: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4073973780

- k3s version  `v.1.25.5+k3s2` is correctly taken as parameter. The test fails correctly due to incompatibility of Rancher dasboard 2.7.1 with k8s >1.25)
![image](https://user-images.githubusercontent.com/37271841/216941037-ffc5d790-e6f1-4bca-9a7f-168791ab900a.png)
