### PR TITLE
Adapting menu tests to new dashboard page

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -51,7 +51,7 @@ describe('Menu testing', () => {
       cy.log(`Epinio version in ABOUT PAGE is ${version}`);
       // Check "Go back" link
       cy.get('.back-link').should('exist').click();
-      cy.get('span.label.no-icon').eq(0).contains('Applications').should('be.visible');
+      cy.get('span.label.no-icon').eq(1).contains('Applications').should('be.visible');
       // Checks version displayed in about page is the same as in main page
       // Later returns to About page
       cy.get('.version.text-muted > a').invoke('text').should('contains', version).then(version_main => {

--- a/cypress/support/epinio.ts
+++ b/cypress/support/epinio.ts
@@ -12,13 +12,14 @@ export class Epinio {
    
     // Check all listed options once accordions are opened
     cy.get('li.child.nav-type').should(($lis) => {
-    expect($lis).to.have.length(6);
-    expect($lis.eq(0)).to.contain('Applications');
-    expect($lis.eq(1)).to.contain('Namespaces');
-    expect($lis.eq(2)).to.contain('Instances');
-    expect($lis.eq(3)).to.contain('Catalog');
-    expect($lis.eq(4)).to.contain('Configurations');
-    expect($lis.eq(5)).to.contain('Application Templates');
+    expect($lis).to.have.length(7);
+    expect($lis.eq(0)).to.contain('Dashboard');
+    expect($lis.eq(1)).to.contain('Applications');
+    expect($lis.eq(2)).to.contain('Namespaces');
+    expect($lis.eq(3)).to.contain('Instances');
+    expect($lis.eq(4)).to.contain('Catalog');
+    expect($lis.eq(5)).to.contain('Configurations');
+    expect($lis.eq(6)).to.contain('Application Templates');
     })      
   }
 


### PR DESCRIPTION
After update of new Dashboard page ([link](https://github.com/rancher/dashboard/pull/7519)), the amount of elements present in the lateral menu has changed.


<img src= https://user-images.githubusercontent.com/37271841/218801047-4e0dd6ad-b3e7-470a-8217-0746758721b7.png width=20% height=20%>

This involves that a couple of position locators on these tests needed to be updated:

 - Check Epinio menu
 - Check binary links from version in menu
 
 Tests passing: [STD UI experimental template #53](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4175951629/jobs/7231582940)