### PR TITLE
[Cypress-pr] - Basic Dex test implementation

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -196,5 +196,22 @@ describe('Login with different users', () => {
       throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
     }
   });
+});
 
-})
+  describe('Dex testing', () => {
+  it('Check Dex login works with granted access', { tags: '@dex-1'}, () => {
+    cy.dexLogin('admin@epinio.io', 'password');
+    cy.dexGrantAccess(true);
+  });
+
+  it('Check Dex deny access', { tags: '@dex-2'}, () => {
+    cy.dexLogin('admin@epinio.io', 'password');
+    cy.dexGrantAccess(false);
+  });
+
+  it('Check users not allowed cannot connect to Dex', { tags: '@dex-3'}, () => {
+    cy.dexLogin('invalid-mail@epinio.io', 'password');
+    cy.contains('Invalid Email Address and password').should('be.visible');
+  });
+});
+

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -8,6 +8,8 @@ declare global {
     interface Chainable {
       // Functions declared in functions.ts
       login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
+      dexLogin(username?: string, password?: string): Chainable<Element>;
+      dexGrantAccess(grantAccess?: boolean,): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;
       deleteAll(label: string,):Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -11,6 +11,13 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     
     cy.visit('/auth/login');
 
+    // Dex bypass to select local meanwhile Dex screen is not default
+    // Refactor to use only cy.get once Dex is available everywhere
+    cy.get("body").then(($body) => {
+    if ($body.text().includes('Dex')) {
+      cy.get('#login-useLocal', {timeout: 10000} ).should('be.visible').click();
+    }});  
+
     cy.byLabel('Username')
       .focus()
       .type(username, {log: false});
@@ -39,6 +46,30 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     login();
   }
 });
+
+// Dex login
+Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'password', grantAccess = true ) => {
+  // Dex connection. Enter username/pwd
+  cy.visit('/auth/login')
+  cy.get('.btn.bg-primary').contains('Log in with Dex').should('be.visible').click({force : true});
+  // Log into Dex Account
+  cy.get('input#login', {timeout: 5000}).should('be.visible').focus().type(username);
+  cy.get('input#password', {timeout: 5000}).should('be.visible').focus().type(password);
+  cy.get('#submit-login').click();
+})
+
+Cypress.Commands.add('dexGrantAccess', (grantAccess = true ) => { 
+  if (grantAccess == true ){
+    cy.get('button[class="dex-btn theme-btn--success"]').contains('Grant Access', {timeout: 5000}).click({force: true})
+    cy.contains('Welcome to Epinio').should('be.visible')
+    cy.get('.user-image.text-right.hand', {timeout: 5000}).click().then(() => {
+      cy.contains('admin@epinio.io')
+    })}
+  else if (grantAccess == false ) {
+    cy.contains('Cancel').click()
+    cy.contains('Approval rejected', {timeout: 5000}).should('be.visible')
+   }
+})
 
 // Search fields by label
 Cypress.Commands.add('byLabel', (label) => {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -12,8 +12,10 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     cy.visit('/auth/login');
 
     // Click on local user meanwhile Dex is default login
+    if (ui != "rancher") {
     cy.get('#login-useLocal', {timeout: 10000} ).should('be.visible').click();
     cy.get('#submit', {timeout: 10000}).contains('Log in with Local User').should('be.visible')
+    };
 
     cy.byLabel('Username')
       .focus()

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -11,12 +11,9 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     
     cy.visit('/auth/login');
 
-    // Dex bypass to select local meanwhile Dex screen is not default
-    // Refactor to use only cy.get once Dex is available everywhere
-    cy.get("body").then(($body) => {
-    if ($body.text().includes('Dex')) {
-      cy.get('#login-useLocal', {timeout: 10000} ).should('be.visible').click();
-    }});  
+    // Click on local user meanwhile Dex is default login
+    cy.get('#login-useLocal', {timeout: 10000} ).should('be.visible').click();
+    cy.get('#submit', {timeout: 10000}).contains('Log in with Local User').should('be.visible')
 
     cy.byLabel('Username')
       .focus()


### PR DESCRIPTION
Implementation of https://github.com/epinio/epinio-end-to-end-tests/issues/238

- Implemented the following basic tests for DEX:

- **Check Dex login works with granted access**: It checks default user `admin@epinio.io` can login in Dex  and after granting access access to Epinio
- **Check Dex deny access**: Check that an allowed user will be able to connect to Dex but not to Epinio when access is not granted
<img src="https://user-images.githubusercontent.com/37271841/220289208-f70f726f-2d90-4254-a76d-2b6783b99b00.png " width=40% height=40%>


- **Check users not allowed cannot connect to Dex**: verifies not allowed users cannot connect to Dex
<img src="https://user-images.githubusercontent.com/37271841/220288792-ade12844-1e81-456a-be57-b4a1812b9972.png" width=40% height=40%>


- Since now default login page brings "Dex Login" as main button and some menu tests failed, I implemented as well a redirection to local user .


## Results:
Test working locally
![dex_ok](https://user-images.githubusercontent.com/37271841/220288264-745806a1-2f1b-4442-b8ed-5a0e95fdfa31.png)

Working for both Rancher and STD UI tests:
[Rancher-UI-1-Chrome #488](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4232666382/jobs/7352909518#step:3:135)
[STD UI experimental template #57](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4232734032/jobs/7352824426#step:14:175)

<img src="https://user-images.githubusercontent.com/37271841/220350459-55f16276-2f89-4da8-b195-29c7ba10860c.png" width=40% height=40%>


