### PR TITLE
Cypress/299 automate dashboard page

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -27,18 +27,11 @@ describe('Menu testing', () => {
     epinio.checkEpinioNav();
   });
 
-  it('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
-    cy.deleteAll('Namespaces')
-    cy.clickEpinioMenu('Applications');
-    cy.get('h1').contains('Welcome to Epinio').should('be.visible')
-    // Verify creating namespace from Get Started button works
-    cy.get('a.btn.role-secondary').contains('Get started').click()
-    cy.clickButton('Create');
-    const defaultNamespace = 'workspace'
-    cy.typeValue({label: 'Name', value: defaultNamespace});
-    cy.clickButton('Create');
-    // Check that the namespace has effectively been created
-    cy.contains(defaultNamespace).should('be.visible');
+   it('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
+    cy.deleteAll('Namespaces');
+    cy.clickEpinioMenu('Dashboard');
+    cy.checkDashboardResources({namespaceNumber: '0'});
+    cy.get('.head-title > h1').contains('Welcome to Epinio', {timeout: 4000}).should('be.visible'); 
   });
 
   it('Check binary links from version in menu', { tags: '@menu-3' }, () => {
@@ -102,6 +95,40 @@ describe('Menu testing', () => {
       else {cy.log(`Server version is too long (${version.length} characters) so binary download will not work and it is currently disabled.`)}
     });
   });
+  it('Test buttons and links in dashboard page',  { tags: ['@menu-3', '@smoke']  },  () => {
+    // // Verify Get started and Issues links
+    cy.get('.head-links').contains('Get started').should('have.attr', 'href').and('equal', 'https://epinio.io/')
+    cy.get('.head-links').contains('Issues').should('have.attr', 'href').and('equal', 'https://github.com/epinio/epinio/issues')
+  
+    // NAMESPACES CARD
+    cy.get('div.d-main > div > a > h1').eq(0).contains('Namespaces').should('be.visible').click();
+    cy.get('h1.m-0').contains('Namespaces').should('be.visible');
+    cy.go('back');
+    // Click on card Create Namespace and check redirection
+    cy.clickButton('Create Namespace');
+    cy.get('.btn.role-secondary.mr-10').contains('Cancel ').should('be.visible').click();
+    cy.go('back');
+  
+    // APPLICATIONS CARD
+    cy.get('div.d-main > div > a > h1').eq(1).contains('Applications').should('be.visible').click();
+    cy.get('h1.m-0').contains('Applications').should('be.visible');
+    cy.go('back');
+    // Click on card Deploy application and check redirection
+    cy.clickButton('Deploy Application');
+    cy.get('[data-testid="epinio_app-source_type"]').should('be.visible');
+    cy.go('back');
+  
+    // SERVICES CARD
+    cy.get('div.d-main > div > a > h1').eq(2).contains('Services').should('be.visible').click();
+    cy.get('h1.m-0').contains('Instances').should('be.visible');
+    cy.go('back');
+    // Click on card "Services" and check redirection
+    cy.get('a.link').contains('mysql-dev').click();
+    cy.contains('mysql-dev').should('be.visible');
+    cy.go('back');
+    cy.get('a.link').contains('redis-dev').click();
+    cy.contains('redis-dev').should('be.visible');
+    });
 });
 
 // Note: this test needs to be adapted for Rancher Dashboard

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -27,7 +27,7 @@ describe('Menu testing', () => {
     epinio.checkEpinioNav();
   });
 
-   it('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
+  it('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
     cy.deleteAll('Namespaces');
     cy.clickEpinioMenu('Dashboard');
     cy.checkDashboardResources({namespaceNumber: '0'});
@@ -97,9 +97,9 @@ describe('Menu testing', () => {
     });
   });
   it('Test buttons and links in dashboard page',  { tags: ['@menu-4', '@smoke']  },  () => {
-    // // Verify Get started and Issues links
-    cy.get('.head-links').contains('Get started').should('have.attr', 'href').and('equal', 'https://epinio.io/')
-    cy.get('.head-links').contains('Issues').should('have.attr', 'href').and('equal', 'https://github.com/epinio/epinio/issues')
+    // Verify Get started and Issues links
+    cy.get('.head-links').contains('Get started').should('have.attr', 'href').and('equal', 'https://epinio.io/');
+    cy.get('.head-links').contains('Issues').should('have.attr', 'href').and('equal', 'https://github.com/epinio/epinio/issues');
   
     // NAMESPACES CARD
     cy.get('div.d-main > div > a > h1').eq(0).contains('Namespaces').should('be.visible').click();
@@ -131,14 +131,14 @@ describe('Menu testing', () => {
     cy.contains('redis-dev').should('be.visible');
     });
 
-  it('Verify metrics in Dashboard page',  { tags: ['@menu-5', '@smoke']  },  () => {
+  it('Verify stats in Dashboard page',  { tags: ['@menu-5', '@smoke']  },  () => {
     cy.createApp({appName: 'testapp', archiveName: 'sample-app.tar.gz', sourceType: 'Archive'});
-    cy.createService({ serviceName: 'mycustom-service-1', catalogType: 'postgresql-dev' })
+    cy.createService({ serviceName: 'mycustom-service-1', catalogType: 'postgresql-dev' });
     cy.createNamespace('ns-1');
-    cy.checkDashboardResources({namespaceNumber: '2', newestNamespaces: ['ns-1', 'workspace'], appNumber: '1', runningapps: '1', servicesNumber: '1' });
+    cy.checkDashboardResources({namespaceNumber: '2', newestNamespaces: ['ns-1', 'workspace'], appNumber: '1', runningApps: '1', servicesNumber: '1' });
     cy.deleteNamespace({namespace:'ns-1'});
-    cy.deleteAll('Applications')
-    cy.deleteAll('Services')
+    cy.deleteAll('Applications');
+    cy.deleteAll('Services');
     });
 
 });

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -32,6 +32,7 @@ describe('Menu testing', () => {
     cy.clickEpinioMenu('Dashboard');
     cy.checkDashboardResources({namespaceNumber: '0'});
     cy.get('.head-title > h1').contains('Welcome to Epinio', {timeout: 4000}).should('be.visible'); 
+    cy.createNamespace('workspace');
   });
 
   it('Check binary links from version in menu', { tags: '@menu-3' }, () => {
@@ -95,7 +96,7 @@ describe('Menu testing', () => {
       else {cy.log(`Server version is too long (${version.length} characters) so binary download will not work and it is currently disabled.`)}
     });
   });
-  it('Test buttons and links in dashboard page',  { tags: ['@menu-3', '@smoke']  },  () => {
+  it('Test buttons and links in dashboard page',  { tags: ['@menu-4', '@smoke']  },  () => {
     // // Verify Get started and Issues links
     cy.get('.head-links').contains('Get started').should('have.attr', 'href').and('equal', 'https://epinio.io/')
     cy.get('.head-links').contains('Issues').should('have.attr', 'href').and('equal', 'https://github.com/epinio/epinio/issues')
@@ -129,6 +130,17 @@ describe('Menu testing', () => {
     cy.get('a.link').contains('redis-dev').click();
     cy.contains('redis-dev').should('be.visible');
     });
+
+  it('Verify metrics in Dashboard page',  { tags: ['@menu-5', '@smoke']  },  () => {
+    cy.createApp({appName: 'testapp', archiveName: 'sample-app.tar.gz', sourceType: 'Archive'});
+    cy.createService({ serviceName: 'mycustom-service-1', catalogType: 'postgresql-dev' })
+    cy.createNamespace('ns-1');
+    cy.checkDashboardResources({namespaceNumber: '2', newestNamespaces: ['ns-1', 'workspace'], appNumber: '1', runningapps: '1', servicesNumber: '1' });
+    cy.deleteNamespace({namespace:'ns-1'});
+    cy.deleteAll('Applications')
+    cy.deleteAll('Services')
+    });
+
 });
 
 // Note: this test needs to be adapted for Rancher Dashboard

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -20,6 +20,7 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
+      checkDashboardResources(namespaceNumber?: string, newestNamespaces?: string, appNumber?: string, runningapps?: string, servicesNumber?: string, ): Chainable<Element>;
       createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string, namespace?: string,): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string ): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -20,7 +20,7 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
-      checkDashboardResources(namespaceNumber?: string, newestNamespaces?: string, appNumber?: string, runningapps?: string, servicesNumber?: string, ): Chainable<Element>;
+      checkDashboardResources(namespaceNumber?: string, newestNamespaces?: string, appNumber?: string, runningApps?: string, servicesNumber?: string, ): Chainable<Element>;
       createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string, namespace?: string,): Chainable<Element>;
       checkApp(appName: string, namespace?: string, route?: string, checkVar?: boolean, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string ): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -27,17 +27,9 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 
     cy.get('button').click();
     cy.wait('@loginReq');
-      if (ui == "rancher") {
-      cy.contains("Get Started", {timeout: 10000}).should('be.visible');
-    } 
-      else{
-          cy.get("body").then(($body) => {
-            if ($body.text().includes('Routes')) {
-              cy.contains('.m-0', 'Applications', {timeout: 20000}).should('be.visible');
-            } else if ($body.text().includes('Welcome to Epinio')) {
-              cy.get('h1').contains('Welcome to Epinio', {timeout: 4000}).should('be.visible')}});
-          }
-        };
+    // Verify Welcome message
+    cy.get('.head-title > h1', {timeout: 4000}).contains('Welcome to Epinio').should('be.visible');
+  };
 
   if (cacheSession) {
     cy.session([username, password], login);
@@ -206,6 +198,34 @@ Cypress.Commands.add('getDetail', ({name, type, namespace='workspace'}) => {
     cy.get('td').contains(name).click();
   });
 });
+
+// Menu functions
+
+// Check Resources on Dashboard page
+Cypress.Commands.add('checkDashboardResources', ({ namespaceNumber, newestNamespaces, appNumber, runningapps, servicesNumber }) => {
+  cy.clickEpinioMenu('Dashboard');
+
+  if (namespaceNumber){
+    cy.get('div.d-header > a > h1').contains('Namespaces ' + namespaceNumber).should('be.visible');
+  };
+  if (newestNamespaces){
+    cy.get('div.d-slot > span > ul > li').eq(0).each( (item, index) => {
+      cy.wrap(item).should('contain.text', newestNamespaces[index]);
+    })
+  };
+  if (appNumber){
+    cy.get('div.d-header > a > h1').eq(1).contains(' Applications ' + appNumber).should('be.visible');
+  };
+  if (runningapps){
+    cy.get('span.numbers-stats').contains(+ runningapps + ' of ' + appNumber + ' Apps ').should('be.visible');
+  };
+  if (servicesNumber){
+    cy.get('div.d-header > a > h1').eq(2).contains(' Services ' + services).should('be.visible');
+  };
+
+});
+
+
 
 // Application functions
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -28,7 +28,7 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     cy.get('button').click();
     cy.wait('@loginReq');
     // Verify Welcome message
-    cy.get('.head-title > h1', {timeout: 4000}).contains('Welcome to Epinio').should('be.visible');
+    cy.get('.head-title > h1', {timeout: 15000}).contains('Welcome to Epinio').should('be.visible');
   };
 
   if (cacheSession) {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -69,7 +69,7 @@ Cypress.Commands.add('byLabel', (label) => {
 
 // Search button by label
 Cypress.Commands.add('clickButton', (label) => {
-  cy.get('.btn', {timeout: 30000}).contains(label).click();
+  cy.get('.btn', {timeout: 30000}).contains(label).click({force: true});
 });
 
 // Ensure that we are in the desired menu
@@ -220,7 +220,7 @@ Cypress.Commands.add('checkDashboardResources', ({ namespaceNumber, newestNamesp
     cy.get('span.numbers-stats').contains(+ runningapps + ' of ' + appNumber + ' Apps ').should('be.visible');
   };
   if (servicesNumber){
-    cy.get('div.d-header > a > h1').eq(2).contains(' Services ' + services).should('be.visible');
+    cy.get('div.d-header > a > h1').eq(2).contains(' Services ' + servicesNumber).should('be.visible');
   };
 
 });

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -218,7 +218,7 @@ Cypress.Commands.add('getDetail', ({name, type, namespace='workspace'}) => {
 // Menu functions
 
 // Check Resources on Dashboard page
-Cypress.Commands.add('checkDashboardResources', ({ namespaceNumber, newestNamespaces, appNumber, runningapps, servicesNumber }) => {
+Cypress.Commands.add('checkDashboardResources', ({ namespaceNumber, newestNamespaces, appNumber, runningApps, servicesNumber }) => {
   cy.clickEpinioMenu('Dashboard');
 
   if (namespaceNumber){
@@ -232,8 +232,8 @@ Cypress.Commands.add('checkDashboardResources', ({ namespaceNumber, newestNamesp
   if (appNumber){
     cy.get('div.d-header > a > h1').eq(1).contains(' Applications ' + appNumber).should('be.visible');
   };
-  if (runningapps){
-    cy.get('span.numbers-stats').contains(+ runningapps + ' of ' + appNumber + ' Apps ').should('be.visible');
+  if (runningApps){
+    cy.get('span.numbers-stats').contains(+ runningApps + ' of ' + appNumber + ' Apps ').should('be.visible');
   };
   if (servicesNumber){
     cy.get('div.d-header > a > h1').eq(2).contains(' Services ' + servicesNumber).should('be.visible');

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -29,13 +29,22 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     cy.wait('@loginReq');
 
     if (ui == "rancher") {
+      // Checks we have entered in Rancher and we see an element within
       cy.contains("Get Started", {timeout: 10000}).should('be.visible');
     }
     else{
-      // Verify Welcome message
-      cy.get('.head-title > h1', {timeout: 15000}).contains('Welcome to Epinio').should('be.visible');
+      cy.get("body").then(($body) => {
+        // Checks welcome message if we have succesfully logged in. 
+        // (Hence user is in Dashboard page)
+        if ($body.text().includes('Dashboard')) {
+          cy.get('.head-title > h1', {timeout: 15000}).contains('Welcome to Epinio').should('be.visible'); 
+        } 
+        // Here the user is in log in page but we are checking for negative login
+        // We check only the title is present in log in page. 
+        else if ($body.text().includes('Welcome to Epinio')) {
+          cy.get('h1').contains('Welcome to Epinio', {timeout: 4000}).should('be.visible')}
+        });
     };
-
   };
 
   if (cacheSession) {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -27,8 +27,15 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 
     cy.get('button').click();
     cy.wait('@loginReq');
-    // Verify Welcome message
-    cy.get('.head-title > h1', {timeout: 15000}).contains('Welcome to Epinio').should('be.visible');
+
+    if (ui == "rancher") {
+      cy.contains("Get Started", {timeout: 10000}).should('be.visible');
+    }
+    else{
+      // Verify Welcome message
+      cy.get('.head-title > h1', {timeout: 15000}).contains('Welcome to Epinio').should('be.visible');
+    };
+
   };
 
   if (cacheSession) {

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -36,6 +36,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
     case 'multipleInstanceAndContainer':
       cy.createApp({appName: appName, archiveName: 'httpd:latest', instanceNum: 5, sourceType: 'Container Image'});
       cy.checkApp({appName: appName, dontCheckRouteAccess: true});
+      cy.checkDashboardResources({ namespaceNumber: '1', appNumber: '1', runningapps: '1' });
       break;
     case 'customRoute':
       cy.createApp({appName: appName, archiveName: archive, route: customRoute, sourceType: 'Archive'});
@@ -82,6 +83,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
     case 'serviceBindUnbindFromServicePage':
       cy.deleteAll('Services')
       cy.createService({ serviceName: 'mycustom-service-2', catalogType: 'postgresql-dev' })
+      cy.checkDashboardResources({ servicesNumber: '1' });
       cy.createApp({ appName: appName, archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image' });
       cy.bindServiceFromSevicesPage({ appName: appName, serviceName: 'mycustom-service-2', bindingOption: 'bind'});
       cy.bindServiceFromSevicesPage({ appName: appName, serviceName: 'mycustom-service-2', bindingOption: 'unbind'});
@@ -175,7 +177,8 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       cy.createConfiguration({configurationName: "config-2", namespace: "ns-2"});    
       cy.createApp({appName: "testapp-1", namespace: "ns-1", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
       cy.createApp({appName: "testapp-2", namespace: "ns-2", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
-      
+      cy.checkDashboardResources({namespaceNumber: '3', newestNamespaces: ['ns-2', 'ns-1'], appNumber: '2', runningapps: '2' });
+
       // Go to Appplications and filter 2 namespaces in namespace filter
       cy.openNamespacesFilter({location: "Applications"})
       cy.filterNamespacesAndCheck({namespace: "ns-1", elemInNamespaceName: "testapp-1", filterOut: false})

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -36,7 +36,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
     case 'multipleInstanceAndContainer':
       cy.createApp({appName: appName, archiveName: 'httpd:latest', instanceNum: 5, sourceType: 'Container Image'});
       cy.checkApp({appName: appName, dontCheckRouteAccess: true});
-      cy.checkDashboardResources({ namespaceNumber: '1', appNumber: '1', runningapps: '1' });
+      cy.checkDashboardResources({ namespaceNumber: '1', appNumber: '1', runningApps: '1' });
       break;
     case 'customRoute':
       cy.createApp({appName: appName, archiveName: archive, route: customRoute, sourceType: 'Archive'});
@@ -177,7 +177,7 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       cy.createConfiguration({configurationName: "config-2", namespace: "ns-2"});    
       cy.createApp({appName: "testapp-1", namespace: "ns-1", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
       cy.createApp({appName: "testapp-2", namespace: "ns-2", archiveName: 'httpd:latest', instanceNum: 1, sourceType: 'Container Image'});
-      cy.checkDashboardResources({namespaceNumber: '3', newestNamespaces: ['ns-2', 'ns-1'], appNumber: '2', runningapps: '2' });
+      cy.checkDashboardResources({namespaceNumber: '3', newestNamespaces: ['ns-2', 'ns-1'], appNumber: '2', runningApps: '2' });
 
       // Go to Appplications and filter 2 namespaces in namespace filter
       cy.openNamespacesFilter({location: "Applications"})


### PR DESCRIPTION
Implementation of: https://github.com/epinio/epinio-end-to-end-tests/issues/299

#### Added tests:
- Test buttons and links in dashboard page
- Verify metrics in Dashboard page

The first one checks:
- User is redirected straight to that page after login
- All links and redirections work

The second one creates an application a service and a namespace and checks:
- Resources count is registered
- New namespaces are added

#### Implemented also:
- Created `checkDashboardResources` function which can check for number of namespaces, applications and services and for the name of newest Namespaces asdded. Added this function as a check in other 3 tests.
- Refactored test `Verify Welcome Screen without Namespaces` to point at Dashboard page and to check Namespaces work in absence of Namespaces.
- Refactored `login` function to fit with this test and added more comments.

#### Checks:
- CI STD UI (selected tests related to these changes) passing: [STD UI experimental template #61](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4304966103/jobs/7506741102#step:14:313)
- CI Rancher tests passing: [Rancher-UI-1-Chrome #499](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4304617196/jobs/7506126743#step:3:90)
![image](https://user-images.githubusercontent.com/37271841/222181543-ceef56d0-6fc8-40a6-ad3f-0ea0ee15308a.png)


