### PR TITLE
Fix secret references

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -70,8 +70,8 @@ jobs:
           EXT_REG_PASSWORD: ${{ secrets.EPINIO_DOCKER_PASSWORD }}
           GHCR_USER: ${{ secrets.GHCR_USER }}
           GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
-          S3_KEY_ID: ${{ secrets.s3_key_id }}
-          S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
+          S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           ## Export information to other jobs
           ETH_DEV=$(ip route | awk '/default via / { print $5 }')
@@ -102,8 +102,8 @@ jobs:
         RANCHER_USER: admin
         RANCHER_PASSWORD: rancherpassword
         RANCHER_URL: https://${{ needs.installation.outputs.MY_HOSTNAME }}/dashboard
-        S3_KEY_ID: ${{ secrets.s3_key_id }}
-        S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
+        S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
         UI: rancher
         EXPERIMENTAL_CHART_BRANCH: ${{ github.event.inputs.experimental_chart_branch }}

--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -33,15 +33,6 @@ on:
         description: Runner on which to execute tests
         required: true
         type: string
-    secrets:
-      ext_reg_user:
-        required: false
-      ext_reg_password:
-        required: false
-      s3_key_id:
-        required: false
-      s3_key_secret:
-        required: false
 
 jobs:
   installation:
@@ -68,12 +59,12 @@ jobs:
           HELM_VERSION: 3.7.0
           K3S_VERSION: v1.24.6+k3s1
           EXT_REG: ${{ inputs.ext_reg }}
-          EXT_REG_USER: ${{ secrets.ext_reg_user }}
-          EXT_REG_PASSWORD: ${{ secrets.ext_reg_password }}
+          EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}
+          EXT_REG_PASSWORD: ${{ secrets.EPINIO_DOCKER_PASSWORD }}
           GHCR_USER: ${{ secrets.GHCR_USER }}
           GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
-          S3_KEY_ID: ${{ secrets.s3_key_id }}
-          S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
+          S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           ## Export information to other jobs
           ETH_DEV=$(ip route | awk '/default via / { print $5 }')
@@ -98,13 +89,13 @@ jobs:
       env:
         CLUSTER_NAME: local
         CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
-        EXT_REG_USER: ${{ secrets.ext_reg_user }}
-        EXT_REG_PASSWORD: ${{ secrets.ext_reg_password }}
+        EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}
+        EXT_REG_PASSWORD: ${{ secrets.EPINIO_DOCKER_PASSWORD }}
         RANCHER_USER: admin
         RANCHER_PASSWORD: rancherpassword
         RANCHER_URL: https://${{ needs.installation.outputs.MY_HOSTNAME }}/dashboard
-        S3_KEY_ID: ${{ secrets.s3_key_id }}
-        S3_KEY_SECRET: ${{ secrets.s3_key_secret }}
+        S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
         UI: rancher
         # EXTRAENV_NAME: SESSION_KEY

--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -17,6 +17,4 @@ jobs:
       # cypress_test: with_default_options.spec.ts
       cypress_test: menu.spec.ts
       runner: ui-e2e-0
-    secrets:
-      ext_reg_user: secrets.EPINIO_DOCKER_USER
-      ext_reg_password: secrets.EPINIO_DOCKER_PASSWORD
+    secrets: inherit

--- a/.github/workflows/scenario_2_firefox_rancher_ui.yml
+++ b/.github/workflows/scenario_2_firefox_rancher_ui.yml
@@ -21,8 +21,4 @@ jobs:
       docker_options: '--user 1000'
       runner: ui-e2e-2
       # ext_reg: '1'
-    secrets:
-      ext_reg_user: secrets.EPINIO_DOCKER_USER
-      ext_reg_password: secrets.EPINIO_DOCKER_PASSWORD
-      # s3_key_id: secrets.AWS_ACCESS_KEY_ID
-      # s3_key_secret: secrets.AWS_SECRET_ACCESS_KEY
+    secrets: inherit


### PR DESCRIPTION
This should fix all the rancher UI tests failures when setting regcreds-ghcr k8s secret for ghrc.io registry.

Also fixed other references to gh secrets in various workflows.

Test runs:
[STD UI experimental template](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4363252204)
[STD-UI-Latest-Firefox](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4363239091)
[STD-UI-Latest-Chrome](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4363237688) NOT RELATED FAILURE
[Rancher-UI-2-Firefox](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4363235556) NOT RELATED FAILURE
[Rancher-UI-1-Chrome](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4363234528) NOT RELATED FAILURE