### PR TITLE
[Cypress] Changing tests viewport to 1314x954

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'cypress'
 
 // export default defineConfig({
 export default defineConfig({
+  viewportWidth: 1314,
+  viewportHeight: 954,
   defaultCommandTimeout: 10000,
   pageLoadTimeout:30000,
   // numTestsKeptInMemory:25,


### PR DESCRIPTION
### Issue:
Sometimes not all elements in UI are displayed in tests due to current viewport set to 1000x660 as can be seen:
![image](https://user-images.githubusercontent.com/37271841/224347837-c2271198-fa26-4007-8ff3-448f79363160.png)

### Done:
Change viewport to 1314x954 shows a less collapsed view of elements:
![image](https://user-images.githubusercontent.com/37271841/224348339-29a50830-af46-4801-ad5c-cea9f53dfa3b.png)


This will hopefully prevent some tests from failing due to element not visible error:

