### PR TITLE
Cypress Adding s3gw test in Rancher.

### DIFF
--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -22,6 +22,13 @@ describe('Epinio installation testing', () => {
     }
   });
 
+  it('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
+    cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false });
+    cy.checkEpinioInstallationRancher();
+    cy.visit('/c/local/explorer#cluster-events');
+    cy.epinioUninstall();
+  });
+
   it('Install Epinio', () => {
     if (Cypress.env('experimental_chart_branch') != null) {
       cy.epinioInstall({ s3: false, extRegistry: false, namespace: 'None' });
@@ -33,29 +40,7 @@ describe('Epinio installation testing', () => {
   });
 
   it('Verify Epinio over ingress URL', () => {
-    if (Cypress.env('experimental_chart_branch') != null) {
-      // Select "All Namespaces" from Namespace filter at the top
-      cy.get('.top > .ns-filter').click({ force: true });
-      cy.get('#all', { timeout: 2000 }).contains('All Namespaces').should('be.visible').click();
-      // Close the namespaces dropdowy
-      cy.get('.top > .ns-filter > .ns-dropdown.ns-open').click({ force: true });
-    }
-
-    // WORKAROUND until Epinio icon will be present again in Rancher UI
-    cy.contains('More Resources').click();
-    cy.contains('Networking').click();
-    cy.contains('Ingresses').click();
-    cy.contains('.ingress-target .target > a', 'epinio-ui')
-      .prevAll('a')
-      .invoke('attr', 'href').then( (href) => {
-        cy.origin(href, (href) => {
-        cy.visit('/');
-        cy.get('h1').contains('Welcome to Epinio').should('be.visible')
-        cy.url().then(url => {
-          const tempUrl= url.replace(/^(https:\/\/.*?)\/.*$/, "$1");
-          cy.log(`Epinio URL from ingress: ${tempUrl}`);
-        });
-      });
-    });
+    cy.checkEpinioInstallationRancher();
   });
+  
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -42,11 +42,12 @@ declare global {
       unbindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string, repoType?: string, branchName?: string,): Chainable<Element>;
       removeHelmRepo(repoName?: string,): Chainable<Element>;
-      epinioInstall(s3?: boolean, extRegistry?: boolean, namespace?: string): Chainable<Element>;
+      epinioInstall(s3?: boolean, s3gw?: boolean, extRegistry?: boolean, namespace?: string): Chainable<Element>;
       createService(serviceName: string, catalogType: string): Chainable<Element>;
       bindServiceFromSevicesPage(appName: string, serviceName: string, bindingOption?: string): Chainable<Element>;
       deleteService(serviceName: string): Chainable<Element>;
       epinioUninstall(): Chainable<Element>;
+      checkEpinioInstallationRancher(): Chainable<Element>;
 
       // Functions declared in tests.ts
       runApplicationsTest(testName: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -935,7 +935,7 @@ Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName =
 });
 
 // Install Epinio via Helm
-Cypress.Commands.add('epinioInstall', ({ s3, s3gw=false, extRegistry, namespace = 'epinio-install' }) => { 
+Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespace = 'epinio-install' }) => {
   cy.clickClusterMenu(['Apps', 'Charts']);
 
   // Make sure we are in the chart screen (test failed here before)


### PR DESCRIPTION
Implements test: https://github.com/epinio/epinio-end-to-end-tests/issues/301

### Summary of what implemented
- Added test for s3gw installation, check of Epinio route correctly deployed and uninstall.
  - This tests is done prior the Epinio installation with `MinIO` since this latest one is the current default storage solution where the rest of tests will continue running after installation.
- Added cleansing mechanism for regular Epinio installation with `MinIO` if previous test did not uninstall correctly 
- Refactored test `Verify Epinio over ingress URL` by adding its content to a new function `checkEpinioInstallationRancher` for re-usabilty and clarity.

--- 

### Local tests results passing:
![image](https://user-images.githubusercontent.com/37271841/224765277-8f5a2533-bc55-48d3-bd5c-e2b3f579c959.png)
![s3gw_ok](https://user-images.githubusercontent.com/37271841/224763353-58961d57-78d0-4b8e-92fe-14de673e0d02.png)

### CI tests results passing: [Master Rancher UI EXPERIMENTAL workflow #55](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4407108700/jobs/7720383761#step:3:130)

![image](https://user-images.githubusercontent.com/37271841/224765083-0bb1c22e-18c0-4cd5-905f-54cac438c502.png)
