### PR TITLE
[Cyoress] Fix timeout misplacement and extending time

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -775,7 +775,7 @@ Cypress.Commands.add('unbindConfiguration', ({appName, configurationName, namesp
   cy.get('.main-row').should('not.contain', configurationName);
 
   // Application status should be equal to 1/1
-  cy.get('.main-row').should('contain', '1/1', {timeout: 16000});
+  cy.get('.main-row', {timeout: 40000}).should('contain', '1/1', );
   cy.wait(2000);
 });
 


### PR DESCRIPTION
Issue:
This Config test `1) Create an application with a configuration, unbind the configuration and delete all` fail quite frequently waiting for app status 

```
  1) Configuration testing
       Create an application with a configuration, unbind the configuration and delete all:
     AssertionError: Timed out retrying after 10000ms: expected '<tr.main-row>' to contain '1/1'
```

This happens because the implicit waiting is set is not correctly set in the specific function and takes only 10 seconds as default, when this process may take >15 seconds and even more at times..

This pr fixes that and extends if needed the time to 40s.

Tested in CI and working: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4447352410/jobs/7808794087#step:14:62

![image](https://user-images.githubusercontent.com/37271841/225908136-07773b0e-f0a8-4c0d-ba93-d3f3bfa2b2a3.png)
