### PR TITLE
Cypress/Adding more dispatches to experimental wf and adapting Rancher tests to Rancher 2.7.2

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -41,6 +41,11 @@ on:
           required: false
           type: string
           default: ''
+        rancher_version:
+          description: Choose rancher version to deploy (dec)
+          required: true
+          type: string
+          default: '2.7.2-rc7'
 
 jobs:
   installation:
@@ -72,15 +77,18 @@ jobs:
           GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
           S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          RANCHER_VERSION: ${{ inputs.rancher_version }}
         run: |
           ## Export information to other jobs
           ETH_DEV=$(ip route | awk '/default via / { print $5 }')
           MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
           export MY_HOSTNAME=$(hostname)
           export EPINIO_SYSTEM_DOMAIN="${MY_IP}.omg.howdoi.website"
+          export RANCHER_VERSION
           echo "MY_IP=${MY_IP}" >> $GITHUB_OUTPUT
           echo "MY_HOSTNAME=${MY_HOSTNAME}" >> $GITHUB_OUTPUT
-          make prepare-e2e-ci-rancher
+          echo "RANCHER_VERSION=${RANCHER_VERSION}" >> $GITHUB_OUTPUT
+          make prepare-e2e-ci-rancher-experimental
 
     outputs:
       MY_HOSTNAME: ${{ steps.installation.outputs.MY_HOSTNAME }}

--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -84,7 +84,6 @@ jobs:
           MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
           export MY_HOSTNAME=$(hostname)
           export EPINIO_SYSTEM_DOMAIN="${MY_IP}.omg.howdoi.website"
-          export RANCHER_VERSION
           echo "MY_IP=${MY_IP}" >> $GITHUB_OUTPUT
           echo "MY_HOSTNAME=${MY_HOSTNAME}" >> $GITHUB_OUTPUT
           echo "RANCHER_VERSION=${RANCHER_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -42,7 +42,7 @@ on:
           type: string
           default: ''
         rancher_version:
-          description: Choose rancher version to deploy (dec)
+          description: Choose rancher version to deploy
           required: true
           type: string
           default: '2.7.2-rc7'

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -38,6 +38,21 @@ on:
         description: Set other docker options
         required: false
         type: string
+      epinio_branch:
+        description: Choose specific branch (default main)
+        required: false
+        type: string
+        default: 'main'
+      helm_version:
+        description: Choose specific helm version (default 3.7.0)
+        required: false
+        type: number
+        default: 3.7.0
+      node_version:
+        description: Choose specific node version (default 16.2.0)
+        required: false
+        type: number
+        default: 16.2.0
 
 jobs:
   E2E-Cypress:
@@ -58,6 +73,7 @@ jobs:
           repository: epinio/epinio
           submodules: recursive
           fetch-depth: 0
+          ref: ${{ inputs.epinio_branch }}
           path: epinio
 
       - name: Checkout Rancher Dashboard repository
@@ -83,7 +99,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.2.0
+          node-version: ${{ inputs.node_version }}
 
       - name: Cache Tools
         uses: actions/cache@v3
@@ -99,7 +115,7 @@ jobs:
         id: installation
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-          HELM_VERSION: 3.7.0
+          HELM_VERSION: ${{ inputs.helm_version }}
           K3S_VERSION: ${{ inputs.k3s_version }}
           EXT_REG: ${{ inputs.ext_reg }}
           S3: ${{ inputs.s3 }}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,12 @@ get-ca: ## Configure Cypress to use the epinio-ca
 create-docker-secret: ## Create docker pull secret to avoid the docker hub rate limit
 	@./scripts/create_docker_secret.sh
 
+install-rancher-experimental: ## Install Rancher via Helm with experimental flags
+	@./scripts/install_rancher_experimental.sh
+
 prepare-e2e-ci-rancher: install-k3s install-helm install-rancher create-docker-secret get-ca ## Tests
+
+prepare-e2e-ci-rancher-experimental: install-k3s install-helm install-rancher-experimental create-docker-secret get-ca ## Tests
 
 prepare-e2e-ci-standalone: install-k3s install-helm install-cert-manager create-docker-secret install-epinio get-ca ## Tests
 

--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -39,7 +39,7 @@ describe('Epinio installation testing', () => {
     }
   });
 
-  it.only('Verify Epinio over ingress URL', () => {
+  it('Verify Epinio over ingress URL', () => {
     cy.checkEpinioInstallationRancher();
   });
   

--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -22,7 +22,7 @@ describe('Epinio installation testing', () => {
     }
   });
 
-  it.skip('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
+  it('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
     cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false });
     cy.checkEpinioInstallationRancher();
     cy.visit('/c/local/explorer#cluster-events');

--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -22,7 +22,7 @@ describe('Epinio installation testing', () => {
     }
   });
 
-  it('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
+  it.skip('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
     cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false });
     cy.checkEpinioInstallationRancher();
     cy.visit('/c/local/explorer#cluster-events');
@@ -39,7 +39,7 @@ describe('Epinio installation testing', () => {
     }
   });
 
-  it('Verify Epinio over ingress URL', () => {
+  it.only('Verify Epinio over ingress URL', () => {
     cy.checkEpinioInstallationRancher();
   });
   

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -106,7 +106,7 @@ describe('Menu testing', () => {
     cy.get('h1.m-0').contains('Namespaces').should('be.visible');
     cy.go('back');
     // Click on card Create Namespace and check redirection
-    cy.clickButton('Create Namespace');
+    cy.get('a.btn.role-secondary', {timeout: 20000}).contains('Create Namespace').should('be.visible').click();
     cy.get('.btn.role-secondary.mr-10').contains('Cancel ').should('be.visible').click();
     cy.go('back');
   
@@ -115,7 +115,7 @@ describe('Menu testing', () => {
     cy.get('h1.m-0').contains('Applications').should('be.visible');
     cy.go('back');
     // Click on card Deploy application and check redirection
-    cy.clickButton('Deploy Application');
+    cy.get('a.btn.role-secondary', {timeout: 20000}).contains('Deploy Application').should('be.visible').click();
     cy.get('[data-testid="epinio_app-source_type"]').should('be.visible');
     cy.go('back');
   
@@ -124,10 +124,10 @@ describe('Menu testing', () => {
     cy.get('h1.m-0').contains('Instances').should('be.visible');
     cy.go('back');
     // Click on card "Services" and check redirection
-    cy.get('a.link').contains('mysql-dev').click();
+    cy.get('a.link', {timeout: 20000}).contains('mysql-dev').should('be.visible').click();
     cy.contains('mysql-dev').should('be.visible');
     cy.go('back');
-    cy.get('a.link').contains('redis-dev').click();
+    cy.get('a.link', {timeout: 20000}).contains('redis-dev').should('be.visible').click();
     cy.contains('redis-dev').should('be.visible');
     });
 

--- a/cypress/e2e/unit_tests/uninstall.spec.ts
+++ b/cypress/e2e/unit_tests/uninstall.spec.ts
@@ -18,7 +18,7 @@ describe('Epinio uninstallation testing', () => {
   });
 
   it('Remove the Epinio helm repo', () => {
-    if (Cypress.env('experimental_chart_branch') != null) {
+    if (Cypress.env('experimental_chart_branch')) {
       cy.removeHelmRepo({ repoName: 'epinio-experimental' });
     }
     else {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1027,7 +1027,7 @@ Cypress.Commands.add('checkEpinioInstallationRancher', () => {
 
   // WORKAROUND until Epinio icon will be present again in Rancher UI
   cy.contains('More Resources').click();
-  cy.contains('Networking').click();
+  cy.contains('Service Discovery').click();
   cy.contains('Ingresses').click();
   cy.contains('.ingress-target .target > a', 'epinio-ui')
     .prevAll('a')

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -954,8 +954,8 @@ Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespac
     }
   });
 
-  // Install epinio-installer chart
-  cy.contains('Epinio deploys Kubernetes').click();
+  // Install epinio-installer chart (Not the experimental one)
+  cy.get('.item.has-description.color1 > .description', {timeout: 20000}).contains('Epinio deploys Kubernetes').click();
   cy.contains('Charts: epinio', { matchCase: false }).should('be.visible');
   cy.clickButton('Install');
 
@@ -1048,7 +1048,7 @@ Cypress.Commands.add('epinioUninstall', () => {
   cy.clickClusterMenu(['Apps', 'Installed Apps'])
 
   // Make sure we are in the 'Installed Apps' screen (test failed here before)
-  cy.contains('header', 'Installed Apps', {timeout: 8000}).should('be.visible');
+  cy.contains('Installed Apps', {timeout: 8000}).should('be.visible');
   cy.contains('epinio:').click();
   cy.clickButton('Delete');
   cy.confirmDelete();

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1026,7 +1026,6 @@ Cypress.Commands.add('checkEpinioInstallationRancher', () => {
   }
 
   // WORKAROUND until Epinio icon will be present again in Rancher UI
-  cy.contains('More Resources').click();
   cy.contains('Service Discovery').click();
   cy.contains('Ingresses').click();
   cy.contains('.ingress-target .target > a', 'epinio-ui')

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1027,7 +1027,8 @@ Cypress.Commands.add('checkEpinioInstallationRancher', () => {
 
   // WORKAROUND until Epinio icon will be present again in Rancher UI
   cy.contains('Service Discovery').click();
-  cy.contains('Ingresses').click();
+  cy.wait(1000)
+  cy.get('span.label.no-icon').contains('Ingress').click()
   cy.contains('.ingress-target .target > a', 'epinio-ui')
     .prevAll('a')
     .invoke('attr', 'href').then( (href) => {

--- a/scripts/install_rancher_experimental.sh
+++ b/scripts/install_rancher_experimental.sh
@@ -24,8 +24,11 @@ helm upgrade --install cert-manager jetstack/cert-manager \
 kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
 
 # Logic for psp enabled according to the Kubernetes version
-KUBERNETES_SERVER_VERSION=$(kubectl version -o json | jq -rj '.serverVersion|.minor' | tr -d '"')
-if  (( $(echo "$KUBERNETES_SERVER_VERSION >= 25" ) )); then
+KUBERNETES_SERVER_VERSION=$(kubectl version -o json | jq -r '.serverVersion|.minor' | tr -d '"')
+thehejik27 minutes ago
+Suggested change:
+
+if  [ "$KUBERNETES_SERVER_VERSION" -ge "25" ] ; then
   echo "Kubernetes Server Version is '1.${KUBERNETES_SERVER_VERSION}' ≥ '1.25'."
   echo "Setting flag 'psp.enabled' to 'false'"
   PSP_ENABLED=false

--- a/scripts/install_rancher_experimental.sh
+++ b/scripts/install_rancher_experimental.sh
@@ -24,14 +24,13 @@ helm upgrade --install cert-manager jetstack/cert-manager \
 kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
 
 # Logic for psp enabled according to the Kubernetes version
-KUBERNETES_SERVER_VERSION=$(kubectl version -o json | jq -rj '.serverVersion|.major,".",.minor' | tr -d '"')
-
-if  (( $(echo "$KUBERNETES_SERVER_VERSION > $1.25" |bc -l) )); then
-  echo "Kubernetes Server Version is '${KUBERNETES_SERVER_VERSION}' ≥ '1.25'."
+KUBERNETES_SERVER_VERSION=$(kubectl version -o json | jq -rj '.serverVersion|.minor' | tr -d '"')
+if  (( $(echo "$KUBERNETES_SERVER_VERSION >= 25" ) )); then
+  echo "Kubernetes Server Version is '1.${KUBERNETES_SERVER_VERSION}' ≥ '1.25'."
   echo "Setting flag 'psp.enabled' to 'false'"
   PSP_ENABLED=false
 else 
-  echo "Kubernetes Server Version is '${KUBERNETES_SERVER_VERSION}' < '1.25' "
+  echo "Kubernetes Server Version is '${1.KUBERNETES_SERVER_VERSION}' < '1.25' "
   echo "Setting flag 'psp.enabled' to 'true'"
   PSP_ENABLED=true
 fi

--- a/scripts/install_rancher_experimental.sh
+++ b/scripts/install_rancher_experimental.sh
@@ -26,11 +26,10 @@ kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
 # Logic for psp enabled according to the Kubernetes version
 KUBERNETES_SERVER_VERSION=$(kubectl version -o json | jq -rj '.serverVersion|.major,".",.minor' | tr -d '"')
 
-if [[ $KUBERNETES_SERVER_VERSION -ge 1.25 ]]
-  then
-    echo "Kubernetes Server Version is '${KUBERNETES_SERVER_VERSION}' ≥ '1.25'."
-    echo "Setting flag 'psp.enabled' to 'false'"
-    PSP_ENABLED=falses
+if  (( $(echo "$KUBERNETES_SERVER_VERSION > $1.25" |bc -l) )); then
+  echo "Kubernetes Server Version is '${KUBERNETES_SERVER_VERSION}' ≥ '1.25'."
+  echo "Setting flag 'psp.enabled' to 'false'"
+  PSP_ENABLED=false
 else 
   echo "Kubernetes Server Version is '${KUBERNETES_SERVER_VERSION}' < '1.25' "
   echo "Setting flag 'psp.enabled' to 'true'"

--- a/scripts/install_rancher_experimental.sh
+++ b/scripts/install_rancher_experimental.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+# Add stable Rancher Helm chart repo
+helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+
+# Add stable CertManager Helm chart repo
+helm repo add jetstack https://charts.jetstack.io
+
+# Mandatory! Otherwise Helm repos are not seen...
+helm repo update
+
+# Cert Manager has to be installed before Rancher
+# kubectl create namespace cattle-system
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set installCRDs=true \
+  --set extraArgs[0]=--enable-certificate-owner-ref=true \
+  --wait
+
+# Wait for cert-manager deployment to be ready
+kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
+
+# Install Rancher
+helm upgrade --install rancher rancher-latest/rancher \
+  --namespace cattle-system \
+  --create-namespace \
+  --set global.cattle.psp.enabled=false \
+  --set hostname=${MY_HOSTNAME} \
+  --version ${RANCHER_VERSION} \
+  --set bootstrapPassword=rancherpassword \
+  --set "extraEnv[0].name=CATTLE_UI_DASHBOARD_INDEX" \
+  --set "extraEnv[0].value=https://releases.rancher.com/dashboard/${DASHBOARD_VERSION}/index.html" \
+  --set "extraEnv[1].name=CATTLE_UI_OFFLINE_PREFERRED" \
+  --set "extraEnv[1].value=Remote" \
+  --wait
+
+# Wait for rancher deployment to be ready
+kubectl rollout status deployment rancher -n cattle-system --timeout=300s


### PR DESCRIPTION
 Adding more dispatches and other adaptations to our e2e tests
 
 ### STD UI Experimental.
 Added dispatches for :
 - Epinio branch selection
 - Helm version
 - Node version

### Rancher UI Experimental
Added:
- Rancher version selector
- Created new script install_rancher_experimental to include PSP enable/disable flag. 
- Logic to enable/disable PSP flag according to the Kubernetes version

### Additional work
- Refactored logic to distinguish between the default Epinio chart (experimental) present in Rancher 2.7.2 and the one uploaded from the repo.
- Refactored where to get the ingresses from in the UI since `Network` was not always available without a refresh
- Refactored locators in menu test `Test buttons and links in dashboard page` to avoid occasional broken tests.
- Removed "falsy" `null` on uninstallation step that produced an incorrect selection of repo installed as in [here](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4593578988/jobs/8111961195#step:3:90) 

### Tests results:
- [Master Rancher UI EXPERIMENTAL workflow #76](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4594830751/jobs/8114456084) (`k3s version`: `v1.25.4+k3s1`; `Rancher version`: `2.7.2`, )
- [STD UI experimental template #76](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4595555076/jobs/8115949767)  (`epinio_branch`: `1726-zero-scale-status`, `helm-version 3.10.2`)
- [Rancher-UI-1-Chrome #539](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4595226660/jobs/8115219595) > normal one

