### PR TITLE
Adapting manifest download to export app menu

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -580,7 +580,9 @@ Cypress.Commands.add('showAppShell', ({appName, namespace='workspace'}) => {
 Cypress.Commands.add('downloadManifest', ({appName}) => {
   cy.clickEpinioMenu('Applications');
   cy.get('.role-multi-action.actions').click();
-  cy.contains('li', 'Download Manifest').click( {force: true} );  
+  cy.contains('li', 'Export App').click( {force: true} );  
+  cy.contains('li', 'Manifest').click( {force: true} );  
+  cy.clickButton('Export')
   // Find downloaded json manifest in download folder & verify name in stdout 
   cy.exec(`find "cypress/downloads/" -name "workspace-${appName}*"`).its('stdout')
   .should('contain', appName);


### PR DESCRIPTION
Fixes: https://github.com/epinio/epinio-end-to-end-tests/issues/313

Adapts test `Download manifest from ui and push an app from it` to download manifest from `App export`

Local test passing:

![2023-04-10_18-47](https://user-images.githubusercontent.com/37271841/230950638-d41e7409-7d44-4e71-ba29-a6296fed70b7.png)

Successful CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4659370191/jobs/8246170544#step:14:148
![image](https://user-images.githubusercontent.com/37271841/230952724-a80104ab-7ca1-435c-8b44-0cb9d426be81.png)


