### PR TITLE
Cypress/ Adapt dex tests to no grant screen access

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -240,7 +240,6 @@ describe('Login with different users', () => {
   describe('Dex testing', () => {
   it('Check Dex login works with granted access', { tags: '@dex-1'}, () => {
     cy.dexLogin('admin@epinio.io', 'password');
-    // cy.dexGrantAccess(true);
   });
 
   it('Check users not allowed cannot connect to Dex', { tags: '@dex-2'}, () => {

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -249,7 +249,7 @@ describe('Login with different users', () => {
   });
 
   it('Check users not allowed cannot connect to Dex', { tags: '@dex-3'}, () => {
-    cy.dexLogin('invalid-mail@epinio.io', 'password');
+    cy.dexLogin('invalid-mail@epinio.io', 'password', { checkLandingPage : false });
     cy.contains('Invalid Email Address and password').should('be.visible');
   });
 });

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -243,12 +243,7 @@ describe('Login with different users', () => {
     // cy.dexGrantAccess(true);
   });
 
-  it.skip('Check Dex deny access', { tags: '@dex-2'}, () => {
-    cy.dexLogin('admin@epinio.io', 'password');
-    cy.dexGrantAccess(false);
-  });
-
-  it('Check users not allowed cannot connect to Dex', { tags: '@dex-3'}, () => {
+  it('Check users not allowed cannot connect to Dex', { tags: '@dex-2'}, () => {
     cy.dexLogin('invalid-mail@epinio.io', 'password', { checkLandingPage : false });
     cy.contains('Invalid Email Address and password').should('be.visible');
   });

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -240,10 +240,10 @@ describe('Login with different users', () => {
   describe('Dex testing', () => {
   it('Check Dex login works with granted access', { tags: '@dex-1'}, () => {
     cy.dexLogin('admin@epinio.io', 'password');
-    cy.dexGrantAccess(true);
+    // cy.dexGrantAccess(true);
   });
 
-  it('Check Dex deny access', { tags: '@dex-2'}, () => {
+  it.skip('Check Dex deny access', { tags: '@dex-2'}, () => {
     cy.dexLogin('admin@epinio.io', 'password');
     cy.dexGrantAccess(false);
   });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -9,7 +9,6 @@ declare global {
       // Functions declared in functions.ts
       login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
       dexLogin(username?: string, password?: string, checkLandingPage?: boolean): Chainable<Element>;
-      dexGrantAccess(grantAccess?: boolean,): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;
       deleteAll(label: string,):Chainable<Element>;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -8,7 +8,7 @@ declare global {
     interface Chainable {
       // Functions declared in functions.ts
       login(username?: string, password?: string, cacheSession?: boolean,): Chainable<Element>;
-      dexLogin(username?: string, password?: string): Chainable<Element>;
+      dexLogin(username?: string, password?: string, checkLandingPage?: boolean): Chainable<Element>;
       dexGrantAccess(grantAccess?: boolean,): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       clickButton(label: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -70,18 +70,6 @@ Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'pass
       cy.contains('admin@epinio.io');})}
 })
 
-Cypress.Commands.add('dexGrantAccess', (grantAccess = true ) => { 
-  if (grantAccess == true ){
-    cy.get('button[class="dex-btn theme-btn--success"]').contains('Grant Access', {timeout: 5000}).click({force: true})
-    cy.contains('Welcome to Epinio').should('be.visible')
-    cy.get('.user-image.text-right.hand', {timeout: 5000}).click().then(() => {
-      cy.contains('admin@epinio.io')
-    })}
-  else if (grantAccess == false ) {
-    cy.contains('Cancel').click()
-    cy.contains('Approval rejected', {timeout: 5000}).should('be.visible')
-   }
-})
 
 // Search fields by label
 Cypress.Commands.add('byLabel', (label) => {

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -63,6 +63,10 @@ Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'pass
   cy.get('input#login', {timeout: 5000}).should('be.visible').focus().type(username);
   cy.get('input#password', {timeout: 5000}).should('be.visible').focus().type(password);
   cy.get('#submit-login').click();
+  // Checking redirection to landing page is correct and Dex user is present
+  cy.contains('Welcome to Epinio').should('be.visible')
+  cy.get('.user-image.text-right.hand', {timeout: 5000}).click().then(() => {
+    cy.contains('admin@epinio.io')
 })
 
 Cypress.Commands.add('dexGrantAccess', (grantAccess = true ) => { 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -55,7 +55,7 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 });
 
 // Dex login
-Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'password', grantAccess = true ) => {
+Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'password', checkLandingPage = true ) => {
   // Dex connection. Enter username/pwd
   cy.visit('/auth/login')
   cy.get('.btn.bg-primary').contains('Log in with Dex').should('be.visible').click({force : true});
@@ -64,9 +64,10 @@ Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'pass
   cy.get('input#password', {timeout: 5000}).should('be.visible').focus().type(password);
   cy.get('#submit-login').click();
   // Checking redirection to landing page is correct and Dex user is present
-  cy.contains('Welcome to Epinio').should('be.visible')
-  cy.get('.user-image.text-right.hand', {timeout: 5000}).click().then(() => {
-    cy.contains('admin@epinio.io')
+  if (checkLandingPage == true) {
+    cy.contains('Welcome to Epinio').should('be.visible')
+    cy.get('.user-image.text-right.hand', {timeout: 5000}).click().then(() => {
+      cy.contains('admin@epinio.io');})}
 })
 
 Cypress.Commands.add('dexGrantAccess', (grantAccess = true ) => { 


### PR DESCRIPTION
Dex tests needed to be adapted after this issue: https://github.com/epinio/epinio/issues/2192
Basically, grant permission screen has been removed by Dex when source is correct.

## Adaptations made:
- Removal of test `Check users not allowed cannot connect to Dex`
- Removal of associated useless functions
- Adapted check-in landing page after login within the `dexLogin` function. By default it checks the user is dex one. To disable use `{ checkLandingPage : false }` parameter within the function

## Results:

- Local:

![image](https://user-images.githubusercontent.com/37271841/231508607-666ca5cd-fa4f-4f3f-b1f6-71dfdbfe9bd0.png)

- CI: 
[Rancher-UI-1-Chrome #552](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4680018509/jobs/8291207604#step:3:135)
[STD UI experimental template #80 ](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4680372758/jobs/8291636573#step:14:159)

