### PR TITLE
[Cypress] Gitlab and source update test and refactoring

### DIFF
--- a/cypress/e2e/unit_tests/applications.spec.ts
+++ b/cypress/e2e/unit_tests/applications.spec.ts
@@ -49,6 +49,11 @@ describe('Applications testing', () => {
   it('Create postgress service, bind/unbind app from service page', { tags: '@appl-8' },  () => {
     cy.runApplicationsTest('serviceBindUnbindFromServicePage');
   });
+
+  it('Push Gitlab app and update sources', { tags: '@appl-9' },  () => {
+    cy.runApplicationsTest('pushGitlabAndUpdateSources');
+  });
+
   // Remove skip when this is fixed: https://github.com/epinio/ui/issues/160
   it.skip('Push application with Github Source type and env vars and check it',  () => {
     cy.runApplicationsTest('gitHubAndEnvVar');

--- a/cypress/e2e/unit_tests/applications.spec.ts
+++ b/cypress/e2e/unit_tests/applications.spec.ts
@@ -50,7 +50,7 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('serviceBindUnbindFromServicePage');
   });
 
-  it('Push Gitlab app and update sources', { tags: '@appl-9' },  () => {
+  it('Push Gitlab app and update sources', { tags: '@appl-9' }, () => {
     cy.runApplicationsTest('pushGitlabAndUpdateSources');
   });
 

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -19,9 +19,11 @@ declare global {
       typeValue(label: string, value: string, noLabel?: boolean, log?: boolean): Chainable<Element>;
       typeKeyValue(key: string, value: string,): Chainable<Element>;
       getDetail(name: string, type: string, namespace?: string): Chainable<Element>;
+      open3dotsMenu(name: string, selection?: string): Chainable<Element>;
+      loadGitRepo(gitUsername?: string, gitRepo?: string, gitBranch?: string, gitCommit?: string): Chainable<Element>;
       checkDashboardResources(namespaceNumber?: string, newestNamespaces?: string, appNumber?: string, runningApps?: string, servicesNumber?: string, ): Chainable<Element>;
-      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string, namespace?: string,): Chainable<Element>;
-      checkApp(appName: string, namespace?: string, route?: string, checkVar?: number, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string ): Chainable<Element>;
+      createApp(appName: string, archiveName: string, sourceType: string, customPaketoImage?: string, customApplicationChart?: string, route?: string, addVar?: string, instanceNum?: number, configurationName?: string, shouldBeDisabled?: boolean, manifestName?: string, serviceName?: string, catalogType?: string, namespace?: string, gitUsername?: string, gitRepo?: string, gitBranch?: string, gitCommit?: string ): Chainable<Element>;
+      checkApp(appName: string, namespace?: string, route?: string, checkVar?: number, checkConfiguration?: boolean, dontCheckRouteAccess?: boolean, instanceNum?: number, serviceName?: string, checkCreatedApp?: string, checkCommit?: string, checkIcon?: string ): Chainable<Element>;
       deleteApp(appName: string, state?: string,): Chainable<Element>;
       restartApp(appName: string, namespace?: string,): Chainable<Element>;
       rebuildApp(appName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -248,13 +248,13 @@ Cypress.Commands.add('selectSourceType', ({ sourceType, archiveName, gitUsername
     case 'Archive':
       cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});   
       break; 
-    case 'GitLab' : case 'GitHub' :
-      cy.loadGitRepo({ gitUsername : gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit })
+    case 'GitLab': case 'GitHub':
+      cy.loadGitRepo({ gitUsername: gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit });
       break;
   };
 });
 
-Cypress.Commands.add('open3dotsMenu', ({ name, selection  }) => {
+Cypress.Commands.add('open3dotsMenu', ({ name, selection }) => {
   // Open 3 dots button
   cy.contains('tr.main-row', name).within(() => {
     cy.get('.icon.icon-actions', {timeout: 5000}).click()

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -150,8 +150,10 @@ Cypress.Commands.add('checkStageStatus', ({numIndex, sourceType, timeout=6000, s
         and it hides the success badge of step 3...
         So we have to wait last step done before continuing */
         cy.get('.tab-label', {timeout: 100000}).should('contain', 'testapp - App Logs');
-        if (sourceType != 'Git URL' && sourceType != 'GitHub') cy.contains('Development Server (http://0.0.0.0:8080) started', {timeout: timeout});
-        cy.get('.tab > .closer').click();
+
+        if (sourceType != 'Git URL' && sourceType != 'GitHub' && sourceType != 'GitLab')
+          cy.contains('Development Server (http://0.0.0.0:8080) started', {timeout: timeout});
+          cy.get('.tab > .closer').click();
       }      
   }
   cy.get(getScope, {timeout: 35000}).contains(status).should('be.visible');
@@ -208,6 +210,86 @@ Cypress.Commands.add('getDetail', ({name, type, namespace='workspace'}) => {
   });
 });
 
+// Load GitHub or Gitlab source type repos
+Cypress.Commands.add('loadGitRepo', ({ gitUsername, gitRepo, gitBranch, gitCommit }) => {
+  cy.get('.labeled-input.edit.has-tooltip',{timeout:5000}).contains('label', 'Username / Organization').should('be.visible')
+
+  // Typing a bit slower to avoid fetching too early
+  cy.get('.labeled-input.edit.has-tooltip > input[type="text"]',{timeout:5000}).focus().clear().type(gitUsername,{delay:250, force:true})
+
+  // Selecting Repository
+  cy.contains('label', 'Repository ').should('be.visible').click();
+  cy.contains(gitRepo).click();
+
+  // Selecting Branch
+  cy.contains('label', 'Branch').should('be.visible').click();
+  cy.contains(gitBranch,{timeout:5000}).should('be.visible').click();
+  
+  // Selecting commit based on commit name
+  cy.get(`tr[data-node-id=${gitCommit}] > td`, {timeout:5000}).eq(0).should('be.visible').click();
+});
+
+// Load apps based on their source types
+Cypress.Commands.add('selectSourceType', ({ sourceType, archiveName, gitUsername, gitRepo, gitBranch, gitCommit }) => {
+  // Adding explicit wait here to attempt avoid failure in CI
+  cy.wait(2000)
+  cy.get('.labeled-select.hoverable').contains('Source Type', {timeout: 10000}).should('be.visible').click( {force: true} );
+  cy.wait(1000)
+  cy.contains(sourceType, {timeout: 10000}).should('be.visible').click({force: true});
+
+  switch (sourceType) {
+    case 'Container Image':
+      cy.typeValue({label: 'Image', value: archiveName}); 
+      break;
+    case 'Git URL':
+      cy.typeValue({label: 'URL', value: archiveName});
+      cy.typeValue({label: 'Branch', value: 'main'}); 
+      break;
+    case 'Archive':
+      cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});   
+      break; 
+    case 'GitLab' : case 'GitHub' :
+      cy.loadGitRepo({ gitUsername : gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit })
+      break;
+  };
+});
+
+Cypress.Commands.add('open3dotsMenu', ({ name, selection  }) => {
+  // Open 3 dots button
+  cy.contains('tr.main-row', name).within(() => {
+    cy.get('.icon.icon-actions', {timeout: 5000}).click()
+  });
+
+  // Open edit config and select option
+  cy.get('.list-unstyled.menu > li > span', {timeout: 15000}).contains(selection).click();
+});
+
+Cypress.Commands.add('updateAppSource', ({ name, sourceType, archiveName, gitUsername, gitRepo, gitBranch, gitCommit }) => {
+  // Ensure we are in Applications
+  cy.clickEpinioMenu('Applications');
+
+  // Open 3 dots button
+  cy.open3dotsMenu({ name: name, selection: 'Edit Config'})
+
+  // Select source update desired
+  cy.selectSourceType({ sourceType: sourceType, archiveName: archiveName, gitUsername: gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit });
+  cy.clickButton('Update Source');
+
+  // Check that each steps are succesfully done
+  cy.checkStageStatus({numIndex: 1});
+  cy.checkStageStatus({numIndex: 2, timeout: 240000, sourceType, name});
+  if (sourceType !== 'Container Image') {
+    cy.checkStageStatus({numIndex: 3, timeout: 240000, sourceType});
+    cy.checkStageStatus({numIndex: 4, timeout: 240000});
+  }
+
+  // Application is created!
+  cy.clickButton('Done');
+  // Give some time to the application to be ready
+  cy.wait(6000);
+});
+
+
 // Menu functions
 
 // Check Resources on Dashboard page
@@ -239,7 +321,7 @@ Cypress.Commands.add('checkDashboardResources', ({ namespaceNumber, newestNamesp
 // Application functions
 
 // Create an Epinio application
-Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPaketoImage, customApplicationChart, route, addVar, instanceNum=1, configurationName, shouldBeDisabled, manifestName, serviceName, catalogType, namespace='workspace'}) => {
+Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPaketoImage, customApplicationChart, route, addVar, instanceNum=1, configurationName, shouldBeDisabled, manifestName, serviceName, catalogType, namespace='workspace', gitUsername, gitRepo, gitBranch, gitCommit}) => {
   var envFile = 'read_from_file.env';  // File to use for the "Read from File" test
 
   cy.clickEpinioMenu('Applications');
@@ -247,37 +329,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
 
   // Select the Source Type if needed
   if (sourceType) {
-    // Adding explicit wait here to attempt avoid failure in CI
-    cy.wait(5000)
-    cy.get('.labeled-select.hoverable').contains('Source Type', {timeout: 10000}).should('be.visible').click( {force: true} );
-    cy.wait(1000)
-    cy.contains(sourceType, {timeout: 10000}).should('be.visible').click({force: true});
-    switch (sourceType) {
-      case 'Container Image':
-        cy.typeValue({label: 'Image', value: archiveName}); 
-        break;
-      case 'Git URL':
-        cy.typeValue({label: 'URL', value: archiveName});
-        cy.typeValue({label: 'Branch', value: 'main'}); 
-        break;
-      case 'Archive':
-        cy.get(' button[data-testid="epinio_app-source_archive_file"] input[type="file"]').attachFile({filePath: archiveName, encoding: 'base64', mimeType: 'application/octet-stream'});   
-        break; 
-      case 'GitHub':
-        cy.get('.labeled-input.edit.has-tooltip',{timeout:5000}).contains('label', 'Username / Organization').should('be.visible')
-        // Typing a bit slower to avoid fetching too early
-        cy.get('.labeled-input.edit.has-tooltip > input[type="text"]',{timeout:5000}).type('epinio',{delay:250, force:true})
-        // Function 'typeValue' not working here
-        // Selecting Repository
-        cy.get('.labeled-select.edit.hoverable',{timeout:5000}).contains('label', 'Repository').should('be.visible').click();
-        cy.contains('example-go').click();
-        // Selecting Branch
-        cy.get('.labeled-select.edit.hoverable',{timeout:5000}).contains('label', 'Branch').should('be.visible').click();
-        cy.contains('main',{timeout:5000}).should('be.visible').click();
-        // Selecting last commit. Currently at the top of the list.
-        cy.get('span.radio-custom',{timeout:5000}).first().should('be.visible').click();
-        break;
-    };
+    cy.selectSourceType({ sourceType: sourceType, archiveName: archiveName, gitUsername: gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit });
   };
 
   if (manifestName) {
@@ -403,7 +455,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
 });
 
 // Ensure that the application is up and running
-Cypress.Commands.add('checkApp', ({appName, namespace='workspace', route, checkVar, checkConfiguration, dontCheckRouteAccess, instanceNum, serviceName, checkCreatedApp}) => {
+Cypress.Commands.add('checkApp', ({appName, namespace='workspace', route, checkVar, checkConfiguration, dontCheckRouteAccess, instanceNum, serviceName, checkCreatedApp, checkCommit, checkIcon}) => {
   cy.clickEpinioMenu('Applications');
 
   // Go to application details
@@ -447,6 +499,18 @@ Cypress.Commands.add('checkApp', ({appName, namespace='workspace', route, checkV
     // Take a screenshot and go back to previous page
     cy.screenshot()
     cy.go('back')
+  }
+
+  if (checkCommit) {
+    //Check deployed commit matches control one
+    cy.get('div.repo-info-revision > span').contains(checkCommit).should('be.visible');
+  }
+
+  if (checkIcon) {
+    //Check Icon of deployed app
+    //Allowed values for checkIcon: file (for file, folder and git url),
+    //gitlab, github and  docker (for images), 
+    cy.get(`.icon.icon-fw.icon-${checkIcon}`).should('be.visible');
   }
 
   // Check binded configurations

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -90,13 +90,21 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.deleteService({ serviceName: 'mycustom-service-2' }); 
       break;
     case 'gitHubAndEnvVar':
-      cy.createApp({appName: appName, addVar: 'go_example', sourceType: 'GitHub'});
+      cy.createApp({appName: 'githubapp', addVar: 'go_example', sourceType: 'GitHub', gitUsername: 'epinio', gitRepo: 'example-go', gitBranch: 'main', gitCommit: 'e84b2a7'});
       cy.checkApp({appName: appName, checkVar: 2});
+      break;
+    case 'pushGitlabAndUpdateSources':
+      cy.createApp({appName: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: '07d2dd79' });
+      cy.checkApp({appName: appName, checkCommit: '07d2dd7'});
+      cy.updateAppSource({name: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: 'bb688311' })
+      cy.checkApp({appName: appName, checkCommit: 'bb68831', checkIcon: 'gitlab'});
+      cy.updateAppSource({name: appName, archiveName: archive, sourceType: 'Archive'});
+      cy.checkApp({appName: appName, checkIcon: 'file'});
       break;
   }
 
   // Delete the tested application
-  cy.deleteApp({appName: appName});
+  // cy.deleteApp({appName: appName});
 });
 
 // Configurations tests

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -104,7 +104,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
   }
 
   // Delete the tested application
-  // cy.deleteApp({appName: appName});
+  cy.deleteApp({appName: appName});
 });
 
 // Configurations tests


### PR DESCRIPTION
Implements: https://github.com/epinio/epinio-end-to-end-tests/issues/322

## Done
- Added test `Push Gitlab app and update sources` within applications to check `Gitlab` source type. It selects the source type, a user, a repo, a branch, and a commit and pushes the app
- Updates the deployed app to a different commit
- Updates the deployed app once again to a file source one
- Extended capabilities to commits and icons on `checkApp` function with `checkCommit` and `checkIcon`
- Refactored functions for reusability

## Results

- [STD UI experimental template #85](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4825639089)
- [STD-UI-Latest-Chrome #491](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4827838002/jobs/8601730431#step:14:148)
![image](https://user-images.githubusercontent.com/37271841/235085593-fb917eb8-936f-4c01-90c3-041516cedd7d.png)
- Local: 
![image](https://user-images.githubusercontent.com/37271841/235087282-c712d073-0bbf-4d61-aa24-4bee5596ba5f.png)
