### PR TITLE
Cypress/325 bump cypress go dependencies

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -176,6 +176,7 @@ jobs:
           SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
+          cache: false
 
       - name: Patch epinio-server
         env:

--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -171,9 +171,9 @@ jobs:
           echo "`pwd`/output/bin" >> $GITHUB_PATH
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         env:
-          SETUP_GO_VERSION: '^1.17.2'
+          SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -64,9 +64,9 @@ jobs:
           path: ui-backend 
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         env:
-          SETUP_GO_VERSION: '^1.18.0'
+          SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/master_std_ui.yml
+++ b/.github/workflows/master_std_ui.yml
@@ -69,6 +69,7 @@ jobs:
           SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
+          cache: false
 
       - name: Install Node
         uses: actions/setup-node@v3

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -95,6 +95,7 @@ jobs:
           SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
+          cache-dependency-path: ~/actions-runner/_work/_tool/go/${{ env.SETUP_GO_VERSION }}/x64/src/go.sum
 
       - name: Install Node
         uses: actions/setup-node@v3

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -90,9 +90,9 @@ jobs:
           path: ui-backend 
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         env:
-          SETUP_GO_VERSION: '^1.18.0'
+          SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
 

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -95,7 +95,7 @@ jobs:
           SETUP_GO_VERSION: '^1.20'
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
-          cache-dependency-path: ~/actions-runner/_work/_tool/go/${{ env.SETUP_GO_VERSION }}/x64/src/go.sum
+          cache: false
 
       - name: Install Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Done
- Bumped go version from `^1.18.0` to `^1.20.0`
- Bumped go actions from `actions/setup-go@v3` to `actions/setup-go@v4`
- Disabled cache (which is enabled by default in [actions/setup-go@v4](https://github.com/actions/setup-go#v4)) to prevent warnings as [this](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4884725317/jobs/8717847163#step:8:19) one by being unable to cache dependencies. Done this after the action itself failed to find the `go.sum` file. I manually introduced the path in one of the commits attempting to use ` cache-dependency-path: subdir/go.sum` as explained [here](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) but failed as well.

## Tests:

[STD-UI-Latest-Firefox #402](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4891803240/jobs/8732774845#step:8:14)
[STD UI experimental template #105](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4891603164/jobs/8732320594#step:8:13)
