### PR TITLE
[Cyoress] changing dex label for sso in tests

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -58,7 +58,7 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'password', checkLandingPage = true ) => {
   // Dex connection. Enter username/pwd
   cy.visit('/auth/login')
-  cy.get('.btn.bg-primary').contains('Log in with Dex').should('be.visible').click({force : true});
+  cy.get('.btn.bg-primary').contains('Log in with SSO').should('be.visible').click({force : true});
   // Log into Dex Account
   cy.get('input#login', {timeout: 5000}).should('be.visible').focus().type(username);
   cy.get('input#password', {timeout: 5000}).should('be.visible').focus().type(password);


### PR DESCRIPTION
Adapting Dext tests to https://github.com/epinio/ui/issues/230

Implemented change on label check from `Log in with Dex` to `Log in with SSO`
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/23dd74e7-c408-4ea9-a302-baaaa78f9c77)


CI successful [here](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4949186005/jobs/8850956292#step:14:78)