### PR TITLE
Add Version dispatch and allow RC in Rancher tests

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -82,6 +82,7 @@ jobs:
           S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           RANCHER_VERSION: ${{ inputs.rancher_version }}
+          EPINIO_VERSION: ${{ inputs.epinio_version }}
         run: |
           ## Export information to other jobs
           ETH_DEV=$(ip route | awk '/default via / { print $5 }')

--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -46,6 +46,10 @@ on:
           required: true
           type: string
           default: '2.7.2-rc7'
+        epinio_version:
+          description: Enter desired Epinio version (default latest) 
+          required: false
+          type: string
 
 jobs:
   installation:
@@ -84,9 +88,11 @@ jobs:
           MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
           export MY_HOSTNAME=$(hostname)
           export EPINIO_SYSTEM_DOMAIN="${MY_IP}.omg.howdoi.website"
+          export EPINIO_VERSION
           echo "MY_IP=${MY_IP}" >> $GITHUB_OUTPUT
           echo "MY_HOSTNAME=${MY_HOSTNAME}" >> $GITHUB_OUTPUT
           echo "RANCHER_VERSION=${RANCHER_VERSION}" >> $GITHUB_OUTPUT
+          echo "EPINIO_VERSION"=$EPINIO_VERSION >> $GITHUB_OUTPUT
           make prepare-e2e-ci-rancher-experimental
 
     outputs:

--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -46,10 +46,6 @@ on:
           required: true
           type: string
           default: '2.7.2-rc7'
-        epinio_version:
-          description: Enter desired Epinio version (default latest) 
-          required: false
-          type: string
 
 jobs:
   installation:
@@ -82,18 +78,15 @@ jobs:
           S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           RANCHER_VERSION: ${{ inputs.rancher_version }}
-          EPINIO_VERSION: ${{ inputs.epinio_version }}
         run: |
           ## Export information to other jobs
           ETH_DEV=$(ip route | awk '/default via / { print $5 }')
           MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
           export MY_HOSTNAME=$(hostname)
           export EPINIO_SYSTEM_DOMAIN="${MY_IP}.omg.howdoi.website"
-          export EPINIO_VERSION
           echo "MY_IP=${MY_IP}" >> $GITHUB_OUTPUT
           echo "MY_HOSTNAME=${MY_HOSTNAME}" >> $GITHUB_OUTPUT
           echo "RANCHER_VERSION=${RANCHER_VERSION}" >> $GITHUB_OUTPUT
-          echo "EPINIO_VERSION"=$EPINIO_VERSION >> $GITHUB_OUTPUT
           make prepare-e2e-ci-rancher-experimental
 
     outputs:

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -53,6 +53,10 @@ on:
         required: false
         type: number
         default: 16.2.0
+      epinio_version:
+        description: Enter desired Epinio version (default latest) 
+        required: false
+        type: string
 
 jobs:
   E2E-Cypress:
@@ -126,6 +130,7 @@ jobs:
           GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
           S3_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          EPINIO_VERSION: ${{ inputs.epinio_version }}
           # EXTRAENV_NAME: SESSION_KEY
           # EXTRAENV_VALUE: 12345
         run: |
@@ -134,7 +139,9 @@ jobs:
           MY_IP=$(ip a s ${ETH_DEV} | egrep -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
           export MY_HOSTNAME=$(hostname)
           export EPINIO_SYSTEM_DOMAIN="${MY_IP}.omg.howdoi.website"
+          export EPINIO_VERSION
           echo "MY_IP=${MY_IP}" >> $GITHUB_OUTPUT
+          echo "EPINIO_VERSION"=$EPINIO_VERSION >> $GITHUB_OUTPUT
           make prepare-e2e-ci-standalone
 
       - name: Patch epinio-ui with latest QA image

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -24,11 +24,11 @@ on:
         required: false
         type: string
         default: "*"
-      grep_test_by_name:
-        description: Grep title
-        required: false
-        type: string
-        default: ''
+      # grep_test_by_name:
+      #   description: Grep title
+      #   required: false
+      #   type: string
+      #   default: ''
       grep_test_by_tag:
         description: Grep tags. For multiple selection separate with spaces
         required: false

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -24,11 +24,6 @@ on:
         required: false
         type: string
         default: "*"
-      # grep_test_by_name:
-      #   description: Grep title
-      #   required: false
-      #   type: string
-      #   default: ''
       grep_test_by_tag:
         description: Grep tags. For multiple selection separate with spaces
         required: false

--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -15,9 +15,11 @@ describe('Epinio installation testing', () => {
 
   it('Add the Epinio helm repo', () => {
     if (Cypress.env('experimental_chart_branch') != null) {
+      cy.allowRancherPreReleaseVersions();
       cy.addHelmRepo({ repoName: 'epinio-experimental', repoUrl: 'https://github.com/epinio/charts.git', repoType: 'git', branchName: Cypress.env('experimental_chart_branch') });
     }
     else {
+      cy.allowRancherPreReleaseVersions();
       cy.addHelmRepo({ repoName: 'epinio-repo', repoUrl: 'https://github.com/epinio/helm-charts', repoType: 'git' });
     }
   });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -42,6 +42,7 @@ declare global {
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;
       bindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;
       unbindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;
+      allowRancherPreReleaseVersions(): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string, repoType?: string, branchName?: string,): Chainable<Element>;
       removeHelmRepo(repoName?: string,): Chainable<Element>;
       epinioInstall(s3?: boolean, s3gw?: boolean, extRegistry?: boolean, namespace?: string): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1008,15 +1008,20 @@ Cypress.Commands.add('deleteService', ({ serviceName }) => {
 
 // Epinio installation functions
 
+// Allow to select pre-release versions
+Cypress.Commands.add('allowRancherPreReleaseVersions', () => {
+  cy.get('div.user-image.text-right.hand', {timeout: 15000}).should('exist').click({ force: true });
+  cy.wait(500)
+  cy.contains('a', 'Preferences', {timeout: 15000}).should('be.visible').click({ force: true });
+  cy.contains('Include Prerelease Versions', {timeout: 15000}).should('exist').click({ force: true });
+  cy.get('.back-link').click({force: true})
+  cy.wait(500);
+  cy.contains('Cluster Dashboard', {timeout: 15000}).should('be.visible');
+});
+
 // Add the Epinio Helm repo
 Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName = 'main' }) => {
-  cy.get('.user-image.text-right.hand').click()
-  cy.get('a[href="/dashboard/prefs"]').contains('Preferences').should('be.visible').click();
-  cy.contains('Include Prerelease Versions').should('exist').click();
-  cy.get('.back-link').click()
-  cy.wait(500);
-
-  // Function starts
+    // Function starts
   cy.clickClusterMenu(['Apps', 'Repositories']);
   // Make sure we are in the 'Repositories' screen (test failed here before)
   cy.contains('header', 'Repositories', { timeout: 8000 }).should('be.visible');

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1010,8 +1010,14 @@ Cypress.Commands.add('deleteService', ({ serviceName }) => {
 
 // Add the Epinio Helm repo
 Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName = 'main' }) => {
-  cy.clickClusterMenu(['Apps', 'Repositories']);
+  cy.get('.user-image.text-right.hand').click()
+  cy.get('a[href="/dashboard/prefs"]').contains('Preferences').should('be.visible').click();
+  cy.contains('Include Prerelease Versions').should('exist').click();
+  cy.get('.back-link').click()
+  cy.wait(500);
 
+  // Function starts
+  cy.clickClusterMenu(['Apps', 'Repositories']);
   // Make sure we are in the 'Repositories' screen (test failed here before)
   cy.contains('header', 'Repositories', { timeout: 8000 }).should('be.visible');
   cy.contains('Create').should('be.visible');

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1010,13 +1010,12 @@ Cypress.Commands.add('deleteService', ({ serviceName }) => {
 
 // Allow to select pre-release versions
 Cypress.Commands.add('allowRancherPreReleaseVersions', () => {
-  cy.get('div.user-image.text-right.hand', {timeout: 15000}).should('exist').click({ force: true });
-  cy.wait(500)
-  cy.contains('a', 'Preferences', {timeout: 15000}).should('be.visible').click({ force: true });
+  // Using visit here instead of clicking in prefs to avoid issues in CI
+  cy.visit('/prefs')
   cy.contains('Include Prerelease Versions', {timeout: 15000}).should('exist').click({ force: true });
-  cy.get('.back-link').click({force: true})
   cy.wait(500);
-  cy.contains('Cluster Dashboard', {timeout: 15000}).should('be.visible');
+  cy.visit('/c/local/explorer')
+  cy.contains('Cluster').should('be.visible')
 });
 
 // Add the Epinio Helm repo

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1020,7 +1020,7 @@ Cypress.Commands.add('allowRancherPreReleaseVersions', () => {
 
 // Add the Epinio Helm repo
 Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName = 'main' }) => {
-    // Function starts
+  // Function starts
   cy.clickClusterMenu(['Apps', 'Repositories']);
   // Make sure we are in the 'Repositories' screen (test failed here before)
   cy.contains('header', 'Repositories', { timeout: 8000 }).should('be.visible');

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -41,6 +41,12 @@ INSTALL_OPTIONS+="
   "
 fi
 
+if [[ -v EPINIO_VERSION ]]; then
+INSTALL_OPTIONS+="
+   --version=${EPINIO_VERSION} \
+  "
+fi
+
 # Install Epinio
 helm upgrade --debug --wait --install -n epinio --create-namespace epinio helm-charts/chart/epinio \
   --set global.domain=${EPINIO_SYSTEM_DOMAIN} \

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -41,6 +41,8 @@ INSTALL_OPTIONS+="
   "
 fi
 
+# Use specific Epinio version if called
+# If not, use latest Epinio version
 if [[ -v EPINIO_VERSION ]]; then
 INSTALL_OPTIONS="--version=${EPINIO_VERSION}"
   echo "using CHARTt=epinio/epinio"
@@ -63,7 +65,8 @@ helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHAR
 # Wait for Epinio deployment to be ready
 kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 
-# Patch Epinio pod, mandatory to use the 'main' version!
+# Patch Epinio pod if no targeting specific versions
+# mandatory to use the 'main' version!
 if [[ ! -v EPINIO_VERSION ]]; then
 make patch-epinio-deployment
 fi

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -45,12 +45,12 @@ fi
 # If not, use latest Epinio version
 if [[ -v EPINIO_VERSION ]]; then
 INSTALL_OPTIONS="--version=${EPINIO_VERSION}"
-  echo "using CHARTt=epinio/epinio"
+  echo "using CHART=epinio/epinio"
   echo "using EPINIO_VERSION=${EPINIO_VERSION}"
   CHART="epinio/epinio"
 else
   echo "using CHART=helm-charts/chart/epinio"
-  CHART="helm-charts/chart/epinio"
+  CHART="helm-charts/chart/epinio/"
 fi
 
 # Install Epinio

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -42,13 +42,17 @@ INSTALL_OPTIONS+="
 fi
 
 if [[ -v EPINIO_VERSION ]]; then
-INSTALL_OPTIONS+="
-   --version=${EPINIO_VERSION} \
-  "
+INSTALL_OPTIONS="--version=${EPINIO_VERSION}"
+  echo "using CHARTt=epinio/epinio"
+  echo "using EPINIO_VERSION=${EPINIO_VERSION}"
+  CHART="epinio/epinio"
+else
+  echo "using CHART=helm-charts/chart/epinio"
+  CHART="helm-charts/chart/epinio"
 fi
 
 # Install Epinio
-helm upgrade --debug --wait --install -n epinio --create-namespace epinio helm-charts/chart/epinio \
+helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHART} \
   --set global.domain=${EPINIO_SYSTEM_DOMAIN} \
   --set server.accessControlAllowOrigin="https://${MY_HOSTNAME}" \
   --set server.disableTracking=true \

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -64,7 +64,9 @@ helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHAR
 kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 
 # Patch Epinio pod, mandatory to use the 'main' version!
+if [[ ! -v EPINIO_VERSION ]]; then
 make patch-epinio-deployment
+fi
 
 # Show Epinio info, could be useful for debugging
 sleep 20


### PR DESCRIPTION
Implements: https://github.com/epinio/epinio-end-to-end-tests/issues/323 

## Done:

- Added dispatch for Epinio version in STD UI experimental workflow
- Removed dispatch for grep title since 10 is maxed and this was unused.
- Selecting 'Include Prerelease Versions'' version in Rancher tests.

## Checks:
 - [STD UI experimental template #125](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4977072308/jobs/8905743210#step:12:3672) (test against version 1.7.0)
 - [Master Rancher UI EXPERIMENTAL workflow #99](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/4977180682/jobs/8906163445)
 
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/7b416d58-a76a-48c7-9cde-c135b8fda53d)
