### PR TITLE
Cypress/fixes exp workflows

### DIFF
--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -39,7 +39,7 @@ on:
         type: string
         default: 'main'
       helm_version:
-        description: Choose specific helm version (default 3.7.0)
+        description: Choose specific helm version (default 3.12.0)
         required: false
         type: number
         default: 3.12.0

--- a/.github/workflows/master_std_ui_experimental.yml
+++ b/.github/workflows/master_std_ui_experimental.yml
@@ -41,13 +41,13 @@ on:
       helm_version:
         description: Choose specific helm version (default 3.12.0)
         required: false
-        type: number
-        default: 3.12.0
+        type: string
+        default: '3.12.0'
       node_version:
         description: Choose specific node version (default 16.2.0)
         required: false
-        type: number
-        default: 16.2.0
+        type: string
+        default: '16.2.0'
       epinio_version:
         description: Enter desired Epinio version (default latest) 
         required: false

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -43,8 +43,8 @@ fi
 
 # Use specific Epinio version if called
 # If not, use latest Epinio version
-if [[ -v EPINIO_VERSION ]]; then
-INSTALL_OPTIONS="--version=${EPINIO_VERSION}"
+if [[ ! -z $EPINIO_VERSION  ]]; then
+ADD_EPINIO_VERSION="--version=${EPINIO_VERSION}"
   echo "using CHART=epinio/epinio"
   echo "using EPINIO_VERSION=${EPINIO_VERSION}"
   CHART="epinio/epinio"
@@ -59,6 +59,7 @@ helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHAR
   --set server.accessControlAllowOrigin="https://${MY_HOSTNAME}" \
   --set server.disableTracking=true \
   ${INSTALL_OPTIONS} \
+  ${ADD_EPINIO_VERSION} \
   --values ../scripts/values-users.yaml \
   --wait
 
@@ -67,7 +68,8 @@ kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 
 # Patch Epinio pod if no targeting specific versions
 # mandatory to use the 'main' version!
-if [[ ! -v EPINIO_VERSION ]]; then
+if [[ -z $EPINIO_VERSION ]]; then
+echo "Patching"
 make patch-epinio-deployment
 fi
 

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -69,8 +69,8 @@ kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 # Patch Epinio pod if no targeting specific versions
 # mandatory to use the 'main' version!
 if [[ -z $EPINIO_VERSION ]]; then
-echo "Patching"
-make patch-epinio-deployment
+  echo "Patching"
+  make patch-epinio-deployment
 fi
 
 # Show Epinio info, could be useful for debugging


### PR DESCRIPTION
## Done
- Currently, when triggering the STD UI experimental template, leaving the parameter 'Enter desired Epinio version' empty will target the latest stable version (ie: v1.8.0) and will leave it unpatched. This is corrected here.
- Fixing typo on the helm version.


Tests:
- [ STD UI experimental template #130](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5022415595/jobs/9005848773#step:12:3678): empty Epinio version param patching latest version::
```
Epinio Server Version: v1.8.0-27-g42aa27ce
Epinio Client Version: v1.8.0-27-g42aa27ce
```
- [STD UI experimental template #131](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5022471188/jobs/9005964461#step:12:3650): entering version 1.7.1 still correctly deploys it (note that the client version still points to latest, but we don't care since we make use of the server version only)

```
Kubernetes Version: v1.25.9+k3s1
Epinio Server Version: v1.7.1
Epinio Client Version: v1.8.0-27-g42aa27ce
```