### PR TITLE
Cypress/remove epinio app env results and adapt timings in sources

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -218,14 +218,17 @@ Cypress.Commands.add('loadGitRepo', ({ gitUsername, gitRepo, gitBranch, gitCommi
   cy.get('.labeled-input.edit.has-tooltip > input[type="text"]',{timeout:5000}).focus().clear().type(gitUsername,{delay:250, force:true})
 
   // Selecting Repository
+  cy.wait(1000)
   cy.contains('label', 'Repository ').should('be.visible').click();
-  cy.contains(gitRepo).click();
+  cy.contains(gitRepo,{timeout:5000}).click();
 
   // Selecting Branch
+  cy.wait(1000)
   cy.contains('label', 'Branch').should('be.visible').click();
   cy.contains(gitBranch,{timeout:5000}).should('be.visible').click();
   
   // Selecting commit based on commit name
+  cy.wait(1000)
   cy.get(`tr[data-node-id=${gitCommit}] > td`, {timeout:5000}).eq(0).should('be.visible').click();
 });
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -235,9 +235,9 @@ Cypress.Commands.add('loadGitRepo', ({ gitUsername, gitRepo, gitBranch, gitCommi
 // Load apps based on their source types
 Cypress.Commands.add('selectSourceType', ({ sourceType, archiveName, gitUsername, gitRepo, gitBranch, gitCommit }) => {
   // Adding explicit wait here to attempt avoid failure in CI
-  cy.wait(2000)
+  cy.wait(3000)
   cy.get('.labeled-select.hoverable').contains('Source Type', {timeout: 10000}).should('be.visible').click( {force: true} );
-  cy.wait(1000)
+  cy.wait(1500)
   cy.contains(sourceType, {timeout: 10000}).should('be.visible').click({force: true});
 
   switch (sourceType) {

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -46,7 +46,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       break;
     case 'envVarsAndGitUrl':
       cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, addVar: 'ui', sourceType: 'Git URL'});
-      cy.checkApp({appName: appName, checkVar: 2});
+      cy.checkApp({appName: appName, checkVar: 1});
       break;
     case 'restartAndRebuild':
       cy.createApp({appName: appName, archiveName: archive, sourceType: 'Archive'});
@@ -58,7 +58,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       break;
     case 'allTests':
       cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, customApplicationChart:applicationChart, instanceNum: 5, addVar: 'ui', route: customRoute, sourceType: 'Git URL'});
-      cy.checkApp({appName: appName, checkVar: 2, route: customRoute});
+      cy.checkApp({appName: appName, checkVar: 1, route: customRoute});
       break;
     case 'downloadManifestAndPushApp':
       cy.createConfiguration({configurationName: configuration});      
@@ -70,7 +70,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.deleteApp({ appName: appName });
       // Create app from manifest solely and check results
       cy.createApp({archiveName: archive, sourceType: 'Archive', manifestName: manifest }); 
-      cy.checkApp({appName: appName , checkConfiguration: true, route: customRoute, checkVar: 2, instanceNum: 2});
+      cy.checkApp({appName: appName , checkConfiguration: true, route: customRoute, checkVar: 1, instanceNum: 2});
       break;
     case 'serviceMysqlBindWordpressPushApp':
       cy.deleteAll('Services')
@@ -91,7 +91,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       break;
     case 'gitHubAndEnvVar':
       cy.createApp({appName: 'githubapp', addVar: 'go_example', sourceType: 'GitHub', gitUsername: 'epinio', gitRepo: 'example-go', gitBranch: 'main', gitCommit: 'e84b2a7'});
-      cy.checkApp({appName: appName, checkVar: 2});
+      cy.checkApp({appName: appName, checkVar: 1});
       break;
     case 'pushGitlabAndUpdateSources':
       cy.createApp({appName: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: '07d2dd79' });
@@ -103,7 +103,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       break;
     case 'downloadChartsAndImages':
       cy.createApp({appName: appName, archiveName: gitUrl, customPaketoImage: paketobuild, addVar: 'go_example', sourceType: 'Git URL'});
-      cy.checkApp({appName: appName, checkVar: 2, checkIcon: 'file'});
+      cy.checkApp({appName: appName, checkVar: 1, checkIcon: 'file'});
       cy.downloadManifestChartsAndImages({ appName: appName, exportType: 'Chart and Images' });
       cy.findExtractCheck({appName: appName, exportType: 'Chart and Images'});
       break;
@@ -150,7 +150,7 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
 
       // Bind the created configuration to the application and check it
       cy.bindConfiguration({appName: appName, configurationName: configuration});
-      cy.checkApp({appName: appName, checkConfiguration: true, checkVar: 2});
+      cy.checkApp({appName: appName, checkConfiguration: true, checkVar: 1});
 
       // Edit the created configuration
       cy.editConfiguration({configurationName: configuration});


### PR DESCRIPTION
## Done

- Removed extra checks for EPINIO_APP_DATA env var since its removal
- Added extra waits for dropdowns related to source type to prevent flakiness

## Tests done:

- [STD-UI-Latest-Chrome #524](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5066389384/jobs/9096129490) (all green except Gitlab one)
- [STD UI experimental template #140](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5067828323/jobs/9099368624#step:14:71) (Gitlab fixed)