### PR TITLE
Skipping test due to unmerged epinio release

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -35,7 +35,7 @@ describe('Menu testing', () => {
     cy.createNamespace('workspace');
   });
 
-  it('Check binary links from version in menu', { tags: '@menu-3' }, () => {
+  it.skip('Check binary links from version in menu', { tags: '@menu-3' }, () => {
     // Check link in main page is present and works after clicking
     cy.get('.version.text-muted > a').should('have.attr', 'href').and('include', '/epinio/about');
     cy.get('.version.text-muted > a').click();


### PR DESCRIPTION
## Issue
Test `Check binary links from version in menu`started to fail on 05/30/23 ([link](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5117461629/jobs/9200568724)) because 1.9.0-rc is out but the assets are not there yet:
```
  1) Menu testing
       Check binary links from version in menu:
     CypressError: `cy.visit()` failed trying to load:

https://github.com/epinio/epinio/releases/tag/v1.9.0
```

This pr is to disable the test until new release is out