### PR TITLE
Changing manifest.json for manifest.yaml

### DIFF
--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -27,7 +27,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
   const gitUrl = 'https://github.com/epinio/example-go';
   const gitUrlWordpress = 'https://github.com/epinio/example-wordpress';
   const configuration = 'configuration01';
-  const manifest = 'manifest.json';
+  const manifest = 'manifest.yaml';
   const customService = 'mycustom-service';
   const customCatalog = 'mysql-dev';
 


### PR DESCRIPTION
## Done
Updating manifest.json to manifest.yaml after merge of https://github.com/rancher/dashboard/pull/8970 (as part of https://github.com/epinio/ui/issues/227) to prevent test failure

## Tests
Local:
```
====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        10.11.0                                                                        │
  │ Browser:        Electron 106 (headless)                                                        │
  │ Node Version:   v18.0.0 (/home/mmartin/.nvm/versions/node/v18.0.0/bin/node)                    │
  │ Specs:          1 found (applications.spec.ts)                                                 │
  │ Searched:       cypress/e2e/unit_tests/applications.spec.ts                                    │
  │ Experiments:    experimentalSessionAndOrigin=true                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  applications.spec.ts                                                            (1 of 1)


  Applications testing
    ✓ Download manifest from ui and push an app from it (339326ms)
```

CI green: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5155221608
