### PR TITLE
[Cypress] Fixing Rancher Install Test Chrome (overlay screen 'loading')

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1025,6 +1025,8 @@ Cypress.Commands.add('allowRancherPreReleaseVersions', () => {
 Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName = 'main' }) => {
   // Function starts
   cy.clickClusterMenu(['Apps', 'Repositories']);
+  // Ensuring overlay screen with 'Loading' is not present 
+  cy.contains('Loading', {timeout: 20000}).should('not.exist')
   // Make sure we are in the 'Repositories' screen (test failed here before)
   cy.contains('header', 'Repositories', { timeout: 8000 }).should('be.visible');
   cy.contains('Create').should('be.visible');
@@ -1158,6 +1160,8 @@ Cypress.Commands.add('epinioUninstall', () => {
 
   // Make sure we are in the 'Installed Apps' screen (test failed here before)
   cy.contains('Installed Apps', {timeout: 8000}).should('be.visible');
+  // Ensuring overlay screen with 'Loading' is not present 
+  cy.contains('Loading', {timeout: 20000}).should('not.exist')
   cy.contains('epinio:').click();
   cy.clickButton('Delete');
   cy.confirmDelete();


### PR DESCRIPTION
## Issue
[Rancher-UI-1-Chrome #613](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5166908233/jobs/9307459896) started to failed during installation a couple of days ago. 

The problem seems to be a new overlay screen with 'Loading' taking a bit to go away both during installation and unistall.
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/657b26f2-9489-4974-b537-2c1ad6c114d5)

## Done
Adding implicit wait for the element 'Loading' not to be present (max 20 secs)

## Tests
Local
![2023-06-05_12-58](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/7c09a43a-1dc8-48ed-88e1-e6cb5feec0b9)

CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5176482912/jobs/9330408393
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/7a20c2a6-b71b-4296-8859-311d5ce3edfc)
