### PR TITLE
[Cypress] Adding homebutton check, About test split and refactors

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -43,16 +43,16 @@ describe('Menu testing', () => {
     // Test in ABOUT page starts here
     cy.get('table > tr > td:nth-child(2)').eq(0).invoke('text').then(version => {
       cy.log(`Epinio version in ABOUT PAGE is ${version}`);
-     
+
       // Slice version to 6 chars if more found (Epinio Server Versions)
       if (version.length > 6) {
         cy.log(`More than 6 chars found in ${version}`)
-        cy.log(`Slicing ${version} to ${version.slice(0,6)}`)
-        version = version.slice(0,6);
+        cy.log(`Slicing ${version} to ${version.slice(0, 6)}`)
+        version = version.slice(0, 6);
       }
-   
+
       // Check Epinio link has correct href
-      cy.get('a[href="https://github.com/epinio/epinio"]', {timeout: 10000}).should('contain', 'Epinio');
+      cy.get('a[href="https://github.com/epinio/epinio"]', { timeout: 10000 }).should('contain', 'Epinio');
 
       // Check "Go back" link
       cy.get('.back-link').should('exist').click();
@@ -63,10 +63,10 @@ describe('Menu testing', () => {
       cy.get('.version.text-muted > a').invoke('text').should('contains', version).then(version_main => {
         cy.log(`Epinio version in MAIN UI is ${version_main}`);
         cy.visit('/epinio/c/default/about');
-        
-      // Check back button turns into home if refreshed
-      cy.reload()
-      cy.get('a.back-link', {timeout: 5000}).contains('Home').should('be.visible');
+
+        // Check back button turns into home if refreshed
+        cy.reload();
+        cy.get('a.back-link', { timeout: 5000 }).contains('Home').should('be.visible');
       });
     });
   });
@@ -80,21 +80,21 @@ describe('Menu testing', () => {
 
       // Slice version to 6 chars if more found (Epinio Server Versions)
       if (version.length > 6) {
-      cy.log(`More than 6 chars found in ${version}`)
-      cy.log(`Slicing ${version} to ${version.slice(0,6)}`)
-      version = version.slice(0,6);
-    }
+        cy.log(`More than 6 chars found in ${version}`)
+        cy.log(`Slicing ${version} to ${version.slice(0, 6)}`)
+        version = version.slice(0, 6);
+      }
 
       // Verify amount of binaries in the page
       cy.get('tr.link > td > a').should('have.length', 3);
       const binOsNames = ['darwin-x86_64', 'linux-x86_64', 'windows-x86_64.zip'];
 
       for (let i = 0; i < binOsNames.length; i++) {
-
-      // Verify binaries names and version match the one in the page
-      cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
-        .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
+        // Verify binaries names and version match the one in the page
+        cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
+          .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
       }
+
       // Downloading using wget to issues with Github when clicking
       // Scoping download solely to Linux amd
       cy.exec('mkdir -p cypress/downloads');

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -35,68 +35,94 @@ describe('Menu testing', () => {
     cy.createNamespace('workspace');
   });
 
-  it.skip('Check binary links from version in menu', { tags: '@menu-3' }, () => {
+  it('Check "About" page and main links', { tags: '@menu-3' }, () => {
     // Check link in main page is present and works after clicking
-    cy.get('.version.text-muted > a').should('have.attr', 'href').and('include', '/epinio/about');
+    cy.get('.version.text-muted > a').should('have.attr', 'href').and('include', '/epinio/c/default/about');
     cy.get('.version.text-muted > a').click();
 
     // Test in ABOUT page starts here
     cy.get('table > tr > td:nth-child(2)').eq(0).invoke('text').then(version => {
       cy.log(`Epinio version in ABOUT PAGE is ${version}`);
+     
+      // Slice version to 6 chars if more found (Epinio Server Versions)
+      if (version.length > 6) {
+        cy.log(`More than 6 chars found in ${version}`)
+        cy.log(`Slicing ${version} to ${version.slice(0,6)}`)
+        version = version.slice(0,6);
+      }
+   
+      // Check Epinio link has correct href
+      cy.get('a[href="https://github.com/epinio/epinio"]', {timeout: 10000}).should('contain', 'Epinio');
+
       // Check "Go back" link
       cy.get('.back-link').should('exist').click();
       cy.get('span.label.no-icon').eq(1).contains('Applications').should('be.visible');
-      // Checks version displayed in about page is the same as in main page
+
+      // Checks version displayed in about page is the same as in main page ()
       // Later returns to About page
       cy.get('.version.text-muted > a').invoke('text').should('contains', version).then(version_main => {
         cy.log(`Epinio version in MAIN UI is ${version_main}`);
-        cy.visit('/epinio/about');
+        cy.visit('/epinio/c/default/about');
+        
+      // Check back button turns into home if refreshed
+      cy.reload()
+      cy.get('a.back-link', {timeout: 5000}).contains('Home').should('be.visible');
       });
-
-      // The following should happen only if server version = 6 chars (v2.0.0 for instance)
-      cy.log(`Server version is (${version.length} characters) long.`)
-      if (version.length < 7) {
-
-        // Check all links work and match the expected version
-
-        // Verify amount of binaries in the page
-        cy.get('tr.link > td > a').should('have.length', 3);
-        const binOsNames = ['darwin-x86_64', 'linux-x86_64', 'windows-x86_64.zip'];
-
-        for (let i = 0; i < binOsNames.length; i++) {
-
-          // Verify binaries names and version match the one in the page
-          cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
-            .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
-        }
-        // Downloading using wget to issues with Github when clicking
-        // Scoping download solely to Linux amd
-        cy.exec('mkdir -p cypress/downloads');
-        cy.exec(`wget -qS  https://github.com/epinio/epinio/releases/download/${version}/epinio-linux-x86_64 -O cypress/downloads/epinio-linux-x86_64`, { failOnNonZeroExit: false }).then((result) => {
-          if (result.code != 0) {
-            cy.task('log', '### ERROR: Could not download binary. Probably an error on Github ###');
-          }
-          cy.task('log', '### Stderr for download binary command starts here.');
-          cy.task('log', result.stderr);
-        });
-
-        // Check link "See all packages" and visit binary page
-        // Check version number in binary page matches the one in Epinio
-        cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').as('href_repo').then(() => {
-          cy.get('@href_repo').should('eq', `https://github.com/epinio/epinio/releases/tag/${version}`);
-          // Giving a bit of time beween latest time hitting github and now
-          cy.wait(2000);
-          cy.origin('https://github.com', { args: { version } }, ({ version }) => {
-            cy.visit(`/epinio/epinio/releases/tag/${version}`, { timeout: 15000 });
-            cy.get('.d-inline.mr-3', { timeout: 15000 }).contains(`${version}`).should('be.visible');
-            cy.screenshot(`epinio-bin-repo-${version}`, { timeout: 15000 });
-          });
-        });
-      }
-      else {cy.log(`Server version is too long (${version.length} characters) so binary download will not work and it is currently disabled.`)}
     });
   });
-  it('Test buttons and links in dashboard page',  { tags: ['@menu-4', '@smoke']  },  () => {
+
+  it.skip('Check binaries, version related links and downloads from About menu', { tags: '@menu-4' }, () => {
+    // Go to About page
+    cy.get('.version.text-muted > a').click();
+
+    // Test in ABOUT page starts here
+    cy.get('table > tr > td:nth-child(2)').eq(0).invoke('text').then(version => {
+
+      // Slice version to 6 chars if more found (Epinio Server Versions)
+      if (version.length > 6) {
+      cy.log(`More than 6 chars found in ${version}`)
+      cy.log(`Slicing ${version} to ${version.slice(0,6)}`)
+      version = version.slice(0,6);
+    }
+
+      // Verify amount of binaries in the page
+      cy.get('tr.link > td > a').should('have.length', 3);
+      const binOsNames = ['darwin-x86_64', 'linux-x86_64', 'windows-x86_64.zip'];
+
+      for (let i = 0; i < binOsNames.length; i++) {
+
+      // Verify binaries names and version match the one in the page
+      cy.get('tr.link > td > a').contains(binOsNames[i]).and('have.attr', 'href')
+        .and('include', `https://github.com/epinio/epinio/releases/download/${version}/epinio-${binOsNames[i]}`);
+      }
+      // Downloading using wget to issues with Github when clicking
+      // Scoping download solely to Linux amd
+      cy.exec('mkdir -p cypress/downloads');
+      cy.exec(`wget -qS  https://github.com/epinio/epinio/releases/download/${version}/epinio-linux-x86_64 -O cypress/downloads/epinio-linux-x86_64`, { failOnNonZeroExit: false }).then((result) => {
+        if (result.code != 0) {
+          cy.task('log', '### ERROR: Could not download binary. Probably an error on Github ###');
+        }
+        cy.task('log', '### Stderr for download binary command starts here.');
+        cy.task('log', result.stderr);
+      });
+
+      // Check link "See all packages" and visit binary page
+      // Check version number in binary page matches the one in Epinio
+      cy.get('.mt-5').contains('See all packages').invoke('attr', 'href').as('href_repo').then(() => {
+        cy.get('@href_repo').should('eq', `https://github.com/epinio/epinio/releases/tag/${version}`);
+        // Giving a bit of time beween latest time hitting github and now
+        cy.wait(2000);
+        cy.origin('https://github.com', { args: { version } }, ({ version }) => {
+          cy.visit(`/epinio/epinio/releases/tag/${version}`, { timeout: 15000 });
+          cy.get('.d-inline.mr-3', { timeout: 15000 }).contains(`${version}`).should('be.visible');
+          cy.screenshot(`epinio-bin-repo-${version}`, { timeout: 15000 });
+        });
+      });
+    });
+  });
+
+ 
+  it('Test buttons and links in dashboard page',  { tags: ['@menu-5', '@smoke']  },  () => {
     // Verify Get started and Issues links
     cy.get('.head-links').contains('Get started').should('have.attr', 'href').and('equal', 'https://epinio.io/');
     cy.get('.head-links').contains('Issues').should('have.attr', 'href').and('equal', 'https://github.com/epinio/epinio/issues');
@@ -131,7 +157,7 @@ describe('Menu testing', () => {
     cy.contains('redis-dev').should('be.visible');
     });
 
-  it('Verify stats in Dashboard page',  { tags: ['@menu-5', '@smoke']  },  () => {
+  it('Verify stats in Dashboard page',  { tags: ['@menu-6', '@smoke']  },  () => {
     cy.createApp({appName: 'testapp', archiveName: 'sample-app.tar.gz', sourceType: 'Archive'});
     cy.createService({ serviceName: 'mycustom-service-1', catalogType: 'postgresql-dev' });
     cy.createNamespace('ns-1');


### PR DESCRIPTION
# Done

- Implemented home button link check (implementation  https://github.com/epinio/epinio-end-to-end-tests/issues/254), reloading page, and observing text change.
- Adding slicing version logic
- Splitting about page test from binaries downloads
- Adapted locators to new UI
- Refactoring

# Tests
Local tests: 
![2023-06-08_09-16](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/94dbb63d-dc6d-433c-b9df-987dd87dfe44)

CI: [STD UI experimental template #146](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5208757596/jobs/9397721036#step:14:64)

Note: left test `Check binaries, version related links and downloads from About menu` still uncommented until the next version is effectively released and binaries can be found