### PR TITLE
Cypress/fix experimental rancher workflow

### DIFF
--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -25,7 +25,13 @@ describe('Epinio installation testing', () => {
   });
 
   it('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
-    cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false });
+    if (Cypress.env('experimental_chart_branch') != null) {
+      cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false, namespace: 'None' });
+    }
+    else {
+      // Boolean must be forced to false otherwise code is failing
+      cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false });
+    }
     cy.checkEpinioInstallationRancher();
     cy.visit('/c/local/explorer#cluster-events');
     cy.epinioUninstall();

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -34,7 +34,7 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
     }
     else{
       cy.get("body").then(($body) => {
-        // Checks welcome message if we have succesfully logged in. 
+        // Checks welcome message if we have successfully logged in. 
         // (Hence user is in Dashboard page)
         if ($body.text().includes('Dashboard')) {
           cy.get('.head-title > h1', {timeout: 15000}).contains('Welcome to Epinio').should('be.visible'); 
@@ -86,7 +86,7 @@ Cypress.Commands.add('clickEpinioMenu', (label) => {
   cy.get('.header').contains('Advanced').click( {force: true} );
   cy.get('.label').contains(label).click( {force: true} );
   cy.location('pathname').should('include', '/' + label.toLocaleLowerCase());
-  // This will check application menu regardles if it has namespaces
+  // This will check application menu regardless if it has namespaces
   cy.get("body").then(($body) => {
     if ($body.text().includes('Routes')) {
       cy.contains('.m-0', 'Applications', {timeout: 20000}).should('be.visible');
@@ -110,7 +110,7 @@ Cypress.Commands.add('confirmDelete', (namespace) => {
 });
 
 Cypress.Commands.add('deleteAll', (label) => {
-  // Must be present in Configurations, Aplications or Namespaces page first
+  // Must be present in Configurations, Applications or Namespaces page first
   if (label == 'Services') {
     cy.get('div.header').contains('Services').click({force: true});
     cy.get('span.label.no-icon').contains('Instances').click({force: true});
@@ -278,7 +278,7 @@ Cypress.Commands.add('updateAppSource', ({ name, sourceType, archiveName, gitUse
   cy.selectSourceType({ sourceType: sourceType, archiveName: archiveName, gitUsername: gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit });
   cy.clickButton('Update Source');
 
-  // Check that each steps are succesfully done
+  // Check that each steps are successfully done
   cy.checkStageStatus({numIndex: 1});
   cy.checkStageStatus({numIndex: 2, timeout: 240000, sourceType, name});
   if (sourceType !== 'Container Image') {
@@ -350,7 +350,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
 
   // Use a custom Application Chart
   if (customApplicationChart) {
-    // For now we asume Advance Settings is opened customPaketoImage
+    // For now we assume Advance Settings is opened customPaketoImage
     // This is to avoid closing Advance Settings.
     // If at any point we want to use this function alone logic should be added
     cy.get('[data-testid="epinio_app-source_appchart"] > div > div >  .vs__selected').contains(' standard (Epinio standard deployment)').should('be.visible').click()
@@ -443,7 +443,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
   // Start application creation
   cy.clickButton('Create');
 
-  // Check that each steps are succesfully done
+  // Check that each steps are successfully done
   cy.checkStageStatus({numIndex: 1});
   cy.checkStageStatus({numIndex: 2, timeout: 240000, sourceType, appName});
   if (sourceType !== 'Container Image') {
@@ -640,7 +640,7 @@ Cypress.Commands.add('showAppShell', ({appName, namespace='workspace'}) => {
   cy.get('.tab > .closer').click();
 });
 
-// Downloading manifest or Chart adn Images (from Export app functionality)
+// Downloading manifest or Chart and Images (from Export app functionality)
 Cypress.Commands.add('downloadManifestChartsAndImages', ({appName, exportType='Manifest'}) => {
   // Get to export app button and click
   cy.clickEpinioMenu('Applications');
@@ -905,7 +905,7 @@ Cypress.Commands.add('bindConfiguration', ({appName, configurationName, namespac
   // And save
   cy.clickButton('Save');
   // Strange sporadic issues happen here
-  // The wait call seems to improve test realibility
+  // The wait call seems to improve test reliability
   cy.wait(6000);
 });
 
@@ -1056,10 +1056,10 @@ Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespac
   cy.contains('header', 'Charts', { timeout: 8000 }).should('be.visible');
 
   // Delete leftovers of other repos if existed.
-  // Ensure we are in local namespace to count only non-essenctial apps
+  // Ensure we are in 'Only User Namespaces' option in Rancher namespaces dropdown to count only non-essential apps
   cy.get('.top > .ns-filter').click({ force: true });
     cy.get('#all_user', { timeout: 2000 }).contains('Only User Namespaces').should('be.visible').click();
-    // Close the namespaces dropdowy
+    // Close the namespaces dropdown
     cy.get('.top > .ns-filter > .ns-dropdown.ns-open').click({ force: true });
   // Reload to ensure installed apps are refreshed
     cy.reload()
@@ -1131,7 +1131,7 @@ Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespac
     cy.get('.CodeMirror textarea').type('{ctrl+end}{enter}extraEnv:{enter}  - name: ' + Cypress.env('extraEnvName') + '{enter}  value: \'' + Cypress.env('extraEnvValue') + '\'', { force: true });
   }
 
-  // Install and check we get successfull installation message with a timeout long enough
+  // Install and check we get successful installation message with a timeout long enough
   cy.clickButton('Install');
   // cy.contains('SUCCESS: helm install', { timeout: 600000 }).should('be.visible');
   cy.contains('SUCCESS: helm', { timeout: 600000 }).should('be.visible');

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1043,6 +1043,10 @@ Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName =
     cy.typeValue({ label: 'Index URL', value: repoUrl });
   }
   cy.clickButton('Create');
+
+  // Ensure created repo is in active state
+  cy.get('span.badge-state.bg-success', {timeout: 30000}).eq(0).contains('Active').should('be.visible');
+  cy.pause()
 });
 
 // Install Epinio via Helm
@@ -1135,6 +1139,10 @@ Cypress.Commands.add('checkEpinioInstallationRancher', () => {
     // Close the namespaces dropdowy
     cy.get('.top > .ns-filter > .ns-dropdown.ns-open').click({ force: true });
   }
+
+  // Ensure app is installed
+  cy.get('span.label.no-icon').contains('Installed Apps').click();
+  cy.get('span.badge-state.bg-success', {timeout: 30000}).contains('Deployed').should('be.visible')
 
   // WORKAROUND until Epinio icon will be present again in Rancher UI
   cy.contains('Service Discovery').click();

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1026,7 +1026,7 @@ Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName =
   // Function starts
   cy.clickClusterMenu(['Apps', 'Repositories']);
   // Ensuring overlay screen with 'Loading' is not present 
-  cy.contains('Loading', {timeout: 20000}).should('not.exist')
+  cy.contains('Loading', {timeout: 35000}).should('not.exist')
   // Make sure we are in the 'Repositories' screen (test failed here before)
   cy.contains('header', 'Repositories', { timeout: 8000 }).should('be.visible');
   cy.contains('Create').should('be.visible');
@@ -1178,7 +1178,7 @@ Cypress.Commands.add('epinioUninstall', () => {
   // Make sure we are in the 'Installed Apps' screen (test failed here before)
   cy.contains('Installed Apps', {timeout: 8000}).should('be.visible');
   // Ensuring overlay screen with 'Loading' is not present 
-  cy.contains('Loading', {timeout: 20000}).should('not.exist')
+  cy.contains('Loading', {timeout: 35000}).should('not.exist')
   cy.contains('epinio:').click();
   cy.clickButton('Delete');
   cy.confirmDelete();

--- a/scripts/install_rancher.sh
+++ b/scripts/install_rancher.sh
@@ -43,7 +43,6 @@ helm upgrade --install rancher rancher-latest/rancher \
   --set global.cattle.psp.enabled=${PSP_ENABLED} \
   --set hostname=${MY_HOSTNAME} \
   --set bootstrapPassword=rancherpassword \
-  --set replicas=1 \
   --set "extraEnv[0].name=CATTLE_UI_DASHBOARD_INDEX" \
   --set "extraEnv[0].value=https://releases.rancher.com/dashboard/${DASHBOARD_VERSION}/index.html" \
   --set "extraEnv[1].name=CATTLE_UI_OFFLINE_PREFERRED" \

--- a/scripts/install_rancher.sh
+++ b/scripts/install_rancher.sh
@@ -43,6 +43,7 @@ helm upgrade --install rancher rancher-latest/rancher \
   --set global.cattle.psp.enabled=${PSP_ENABLED} \
   --set hostname=${MY_HOSTNAME} \
   --set bootstrapPassword=rancherpassword \
+  --set replicas=1 \
   --set "extraEnv[0].name=CATTLE_UI_DASHBOARD_INDEX" \
   --set "extraEnv[0].value=https://releases.rancher.com/dashboard/${DASHBOARD_VERSION}/index.html" \
   --set "extraEnv[1].name=CATTLE_UI_OFFLINE_PREFERRED" \


### PR DESCRIPTION
## Done

- Added logic on the s3gw step to differentiate between experimental and non-experimental charts.
- Added implicit waits for confirmation badges as `Deployed` or `Active` when installing Epinio.
- Added longer implicit waits for the "Loading" overlay screen.
- Improved cleansing logic of apps toggling explicitly to the current namespace in rancher dropdowns.

## Tests
### Local:
![2023-06-14_17-52](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/0fdc2ebf-9e4b-4596-8c78-5a6baeb6501d)

### CI:
Note that here the important thing is the success on the `cypress-epinio-installation` part; the job on `cypress-epinio-tests` have some failures related to updated locators on more current UI images not present on the deployed chart.

- Experimental one with branch `epinio-1.8.1-integration`
  - With Rancher version `2.7.3`: [Master Rancher UI EXPERIMENTAL workflow #128](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5275676094/jobs/9541421080#step:5:23)
  - With Rancher version `2.7.4`: [Master Rancher UI EXPERIMENTAL workflow #129](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5275930760/jobs/9541986593#step:5:23)
  - With Rancher version `2.7.5-rc2`: [Master Rancher UI EXPERIMENTAL workflow #131](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5277955766/jobs/9546719891#step:3:117)

- Control on normal [Rancher-UI-1-Chrome #628](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5276381555/jobs/9543021255#step:2:186)