### PR TITLE
Change `cy.visit` in about page for link click + implicit wait for loading

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -62,7 +62,8 @@ describe('Menu testing', () => {
       // Later returns to About page
       cy.get('.version.text-muted > a').invoke('text').should('contains', version).then(version_main => {
         cy.log(`Epinio version in MAIN UI is ${version_main}`);
-        cy.visit('/epinio/c/default/about');
+        cy.get('.version.text-muted > a', {timeout: 15000}).click()
+        cy.contains('See all packages', {timeout: 15000}).should('be.visible')
 
         // Check back button turns into home if refreshed
         cy.reload();


### PR DESCRIPTION
PR for https://github.com/epinio/epinio-end-to-end-tests/issues/347

## Issue
The issue seemed to be related with the attempt to reload a page after executing a `cy.visit` that did not seem to finish. Changing the behavior of the visit to actually following the link and explicitly waiting for the page to load before reloading seems a  logical solution

## Done
Changed cv.visit for clicking on the link and implicit wait of elements

## Tests
Successfully passed 3 times:
- https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5355961505
- https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5356224586
- https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5356487433