### PR TITLE
Cypress/354 test config upload from file

### DIFF
--- a/cypress/e2e/unit_tests/configurations.spec.ts
+++ b/cypress/e2e/unit_tests/configurations.spec.ts
@@ -26,4 +26,8 @@ describe('Configuration testing', () => {
   it('Bind a created configuration to an existing application, edit configuration and delete all', { tags: '@config-2' }, () => {
     cy.runConfigurationsTest('bindConfigurationOnApp');
   });
+
+  it('Create configuration from file', { tags: '@config-3' }, () => {
+    cy.runConfigurationsTest('createConfigfromFile');
+  });
 });

--- a/cypress/fixtures/upload_config_name
+++ b/cypress/fixtures/upload_config_name
@@ -1,0 +1,1 @@
+upload_config_value

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -37,7 +37,7 @@ declare global {
       filterNamespacesAndCheck(namespace: string, elemInNamespaceName?: string, filterOut?: boolean,): Chainable<Element>;
       checkOutcomeFilteredNamespaces(expectedNumFilteredNamespaces: number, expectedNumElemInNamespaces: number, expectedNameElementInNamespaces?:string,): Chainable<Element>;
       selectNamespaceinComboBox(namespace: string,): Chainable<Element>;    
-      createConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
+      createConfiguration(configurationName: string, fromFile?: boolean, fromFileUpload?: boolean, namespace?: string,): Chainable<Element>;
       editConfiguration(configurationName: string, fromFile?: boolean, namespace?: string,): Chainable<Element>;
       deleteConfiguration(configurationName: string, namespace?: string,): Chainable<Element>;
       bindConfiguration(appName: string, configurationName: string, namespace?: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -791,7 +791,7 @@ Cypress.Commands.add('selectNamespaceinComboBox', ({namespace}) => {
 // Configurations functions
 
 // Create a configuration
-Cypress.Commands.add('createConfiguration', ({configurationName, fromFile, namespace='workspace'}) => {
+Cypress.Commands.add('createConfiguration', ({configurationName, fromFile, fromFileUpload, namespace='workspace'}) => {
   var configurationFile = 'read_from_file.configuration';  // File to use for the "Read from File" test
 
   cy.clickEpinioMenu('Configurations');
@@ -814,7 +814,13 @@ Cypress.Commands.add('createConfiguration', ({configurationName, fromFile, names
     cy.get('.key > input').should('have.value', 'config_var');
     // Here we use alternative locator due to field contains also upload element
     cy.get('div[data-testid="code-mirror-multiline-field"]').should('contain.text', 'config_value');
-  } else {
+  } 
+  else if (fromFileUpload === true) {
+    cy.get('button.file-selector > input').eq(0).selectFile('cypress/fixtures/upload_config_name', {force: true});
+    cy.get('.key > input').should('have.value', 'upload_config_name' );
+    cy.get('div[data-testid="code-mirror-multiline-field"]').should('contain.text', 'upload_config_value');
+  }
+  else {
     cy.typeKeyValue({key: '.kv-item.key > input', value: 'test_data'});
     // Using alternative locator as clear cannot be easily used 
     // due to upload element present within element

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -159,6 +159,10 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
       cy.deleteApp({appName: appName});
       cy.deleteConfiguration({configurationName: configuration});
       break;
+    case 'createConfigfromFile':
+      // Create another new configuration uploading a file
+      cy.createConfiguration({configurationName: configuration, fromFileUpload: true});
+      break;
   }
 });
 

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -122,7 +122,6 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
   switch (testName) {
     case 'newAppWithConfiguration':
       // Create a new configuration
-      cy.wait(5000); // Workaround for https://github.com/rancher/dashboard/issues/5240
       cy.createConfiguration({configurationName: configuration});
 
       // Create an application with the newly created configuration and check it
@@ -137,11 +136,9 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
       cy.deleteApp({appName: appName});
       
       // Delete the created configuration
-      cy.deleteConfiguration({configurationName: configuration});
       break;
     case 'bindConfigurationOnApp':
       // Create another new configuration
-      cy.wait(5000); // Workaround for https://github.com/rancher/dashboard/issues/5240
       cy.createConfiguration({configurationName: configuration, fromFile: true});
 
       // Create an application *WITHOUT* any configuration
@@ -157,13 +154,14 @@ Cypress.Commands.add('runConfigurationsTest', (testName: string) => {
 
       // Delete the tested application and the configuration
       cy.deleteApp({appName: appName});
-      cy.deleteConfiguration({configurationName: configuration});
       break;
     case 'createConfigfromFile':
       // Create another new configuration uploading a file
       cy.createConfiguration({configurationName: configuration, fromFileUpload: true});
       break;
+    
   }
+  cy.deleteConfiguration({configurationName: configuration});
 });
 
 // Namespaces tests


### PR DESCRIPTION
## Done
- Implements ui test for  upload config values from files as in : https://github.com/epinio/epinio-end-to-end-tests/issues/354
- Removed unnecessary waits in configuration tests and refactored deletion.

## Tests:

- CI (all config tests passing): [STD UI experimental template #155](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5465737715/jobs/9949613070#step:14:64)
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/2d8b5b20-e4d5-4c12-814d-a7b323169466)



- Local: 
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/b5d00583-7656-438d-a337-9813c2764fe5)
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/439b2e33-39fd-434f-a576-cb599c537e66)
