### PR TITLE
Cypress/namespace creation outside default

### DIFF
--- a/cypress/e2e/unit_tests/namespaces.spec.ts
+++ b/cypress/e2e/unit_tests/namespaces.spec.ts
@@ -22,4 +22,9 @@ describe('Namespaces testing', () => {
   it('Test namespace filter with 3 namespaces, 2 apps and 2 configurations', { tags: '@ns-2' }, () => {
     cy.runNamespacesTest('namespaceFilter');
   });
+
+  it('Create a Namespace from multiple services', () => {
+    cy.runNamespacesTest('newNamespaceFromResource');
+  });
+  
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -32,6 +32,7 @@ declare global {
       downloadManifestChartsAndImages(appName: string, exportType?: string): Chainable<Element>;
       findExtractCheck(appName?: string, exportType?: string): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
+      createNamespaceFromResource(namespace: string): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;
       openNamespacesFilter(location: string, namespace?: string, appName?: string, configurationName?: string,): Chainable<Element>;
       filterNamespacesAndCheck(namespace: string, elemInNamespaceName?: string, filterOut?: boolean,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -698,6 +698,48 @@ Cypress.Commands.add('createNamespace', (namespace) => {
   cy.contains(namespace).should('be.visible');
 });
 
+// Create an Epinio namespace directly from a Service (configuration,instances,... )
+Cypress.Commands.add('createNamespaceFromResource', (namespace) => {
+  if (namespace === 'ns-from-application'){
+    // Namespace from application requires  a source first
+    // Using Container image as sample
+    cy.get('.labeled-select').click();
+    cy.contains('Container Image', {timeout: 120000}).click();
+    cy.typeValue({label: 'Image', value: 'httpd:latest'}); 
+    cy.clickButton('Next');
+    }  
+
+    if (namespace === 'ns-from-configuration'){
+    cy.get("input[placeholder='e.g. foo']").type('foo')
+    cy.get('div[data-testid="code-mirror-multiline-field"]').type('bar')}
+
+    else if (namespace === 'ns-from-instance'){
+    cy.get("input[placeholder='Select the type of Service to create']").click()
+    cy.get('ul>li').contains('mysql-dev (A MySQL service that can be used during development').click()
+    }
+
+    // Open Namespace dropdown and select new Namespace
+    cy.get('div.vs__selected-options').eq(0).click()
+    cy.get('li.vs__dropdown-option').contains('Create a New Namespace').click({force: true})
+    // Add Namespace and rest of values
+    cy.typeValue({label: 'Namespace', value: namespace});
+    cy.get("input[placeholder='A unique name']").type(`samplename-${namespace}`)
+
+    if (namespace === 'ns-from-application'){
+      cy.clickButton('Next');
+      cy.clickButton('Create');
+      // We don't need to wait for the app to be fully deployed 
+      // so we go straight to namespaces to check it has been created.
+      cy.clickEpinioMenu('Namespaces');
+    } 
+    else {
+      cy.clickButton('Create');
+    }
+ 
+    // Check that the namespace has effectively been created
+    cy.contains(namespace).should('be.visible');
+});
+
 // Delete an Epinio namespace
 Cypress.Commands.add('deleteNamespace', ({namespace, appName}) => {
   cy.clickEpinioMenu('Namespaces');

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -170,6 +170,9 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
   const archive = 'sample-app.tar.gz';
   const defaultNamespace = 'workspace';
   const namespace = 'mynamespace';
+  const nsFromConfiguration = 'ns-from-configuration'
+  const nsFromInstance = 'ns-from-instance'
+  const nsFromApplication = 'ns-from-application'
 
   switch (testName) {
     case 'newNamespace':
@@ -217,5 +220,22 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
       cy.checkOutcomeFilteredNamespaces({expectedNumFilteredNamespaces: 0, expectedNumElemInNamespaces: 2, expectedNameElementInNamespaces: "config-2"})
       break;
       
+    case 'newNamespaceFromResource':
+      // Create Namespace from configuration   
+      cy.clickEpinioMenu('Configurations');
+      cy.clickButton('Create');
+      cy.createNamespaceFromResource(nsFromConfiguration);
+
+      // Create Namespace from instances
+      cy.get('div.header > i').eq(0).click();
+      cy.contains('Instances').click(); 
+      cy.clickButton('Create');
+      cy.createNamespaceFromResource(nsFromInstance);
+
+      // Create Namespace from application
+      cy.clickEpinioMenu('Applications');
+      cy.clickButton('Create');
+      cy.createNamespaceFromResource(nsFromApplication);
+      break;
   }
 });

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -177,7 +177,6 @@ Cypress.Commands.add('runNamespacesTest', (testName: string) => {
   switch (testName) {
     case 'newNamespace':
       // Create a new namespace
-      cy.wait(5000); // Workaround for https://github.com/rancher/dashboard/issues/5240
       cy.createNamespace(namespace);
 
       // Create an application on the new namespace and check it


### PR DESCRIPTION
Implementation of https://github.com/epinio/epinio-end-to-end-tests/issues/180

## Summary
- Added a new test to check namespace creation directly from Applications, Configurations, and Services is possible.
- The test will deploy an app, config and service in new namespaces created specifically on each one of these resources

![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/aa2dd86d-90ce-405a-84b7-dcbcbb43d4e2)

## Tested:
Locally:
![2023-07-07_09-48](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/7b682f1e-01c0-4022-94fb-76723d78c67d)


CI: [STD UI experimental template #158](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5484199419/jobs/9991437310#step:14:64)
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/1d1923b9-f699-4b8c-b02c-bd4d06cfe248)
