### PR TITLE
Added new commit redeploy logic 

### DIFF
--- a/cypress/e2e/unit_tests/applications.spec.ts
+++ b/cypress/e2e/unit_tests/applications.spec.ts
@@ -50,7 +50,7 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('serviceBindUnbindFromServicePage');
   });
 
-  it('Push Gitlab app and update sources', { tags: '@appl-9' }, () => {
+  it('Push Gitlab app, redeploy from commit and update sources', { tags: '@appl-9' }, () => {
     cy.runApplicationsTest('pushGitlabAndUpdateSources');
   });
 

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -31,6 +31,7 @@ declare global {
       showAppShell(appName: string, namespace?: string,): Chainable<Element>;
       downloadManifestChartsAndImages(appName: string, exportType?: string): Chainable<Element>;
       findExtractCheck(appName?: string, exportType?: string): Chainable<Element>;
+      redeployFromCommit(gitCommit: string): Chainable<Element>;
       createNamespace(namespace: string,): Chainable<Element>;
       createNamespaceFromResource(namespace: string): Chainable<Element>;
       deleteNamespace(namespace: string, appName?: string,): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -687,7 +687,11 @@ Cypress.Commands.add('findExtractCheck', ({ appName, exportType='Manifest' }) =>
 Cypress.Commands.add('redeployFromCommit', ({gitCommit}) => {
   cy.contains('Git commits').click(); // Select Git commit tab
   cy.open3dotsMenu({ name: gitCommit, selection: 'Redeploy'}) // Redeploy to desired commit
+  // Checking for commit selection to be displayed
+  cy.get(`tr.main-row[data-node-id=${gitCommit}] > td > label > span[aria-checked="true"]`).should('be.visible')
   cy.clickButton('Update Source');
+  // Waiting for update screen to be lodaded.
+  cy.contains('Edit:').should('be.visible');
   // Wait for button 'Done' to be enabled ( or 'not disabled')
   cy.get('button.btn.role-primary[disabled]', {timeout: 120000}).should('not.exist')
   // Close all tabs to clear screen

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -684,6 +684,17 @@ Cypress.Commands.add('findExtractCheck', ({ appName, exportType='Manifest' }) =>
 
 })
 
+Cypress.Commands.add('redeployFromCommit', ({gitCommit}) => {
+  cy.contains('Git commits').click(); // Select Git commit tab
+  cy.open3dotsMenu({ name: gitCommit, selection: 'Redeploy'}) // Redeploy to desired commit
+  cy.clickButton('Update Source');
+  // Wait for button 'Done' to be enabled ( or 'not disabled')
+  cy.get('button.btn.role-primary[disabled]', {timeout: 120000}).should('not.exist')
+  // Close all tabs to clear screen
+  cy.get('.tab > .closer').click({ multiple: true });
+  // Application is created!
+  cy.clickButton('Done');
+})
 
 // Namespace functions
 

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -94,8 +94,8 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.checkApp({appName: appName, checkVar: 1});
       break;
     case 'pushGitlabAndUpdateSources':
-      cy.createApp({appName: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: '07d2dd79' });
-      cy.checkApp({appName: appName, checkCommit: '07d2dd7'}); 
+      cy.createApp({appName: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: '07d2dd79'});
+      cy.checkApp({appName: appName, checkCommit: '07d2dd7'});
       cy.redeployFromCommit({gitCommit: 'bb688311'});
       cy.checkApp({appName: appName, checkCommit: 'bb68831', checkIcon: 'gitlab'});
       cy.updateAppSource({name: appName, archiveName: archive, sourceType: 'Archive'});

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -95,8 +95,8 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       break;
     case 'pushGitlabAndUpdateSources':
       cy.createApp({appName: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: '07d2dd79' });
-      cy.checkApp({appName: appName, checkCommit: '07d2dd7'});
-      cy.updateAppSource({name: appName, sourceType: 'GitLab', gitUsername: 'richard-cox', gitRepo: 'epinio-sample-app', gitBranch: 'main', gitCommit: 'bb688311' })
+      cy.checkApp({appName: appName, checkCommit: '07d2dd7'}); 
+      cy.redeployFromCommit({gitCommit: 'bb688311'});
       cy.checkApp({appName: appName, checkCommit: 'bb68831', checkIcon: 'gitlab'});
       cy.updateAppSource({name: appName, archiveName: archive, sourceType: 'Archive'});
       cy.checkApp({appName: appName, checkIcon: 'file'});
@@ -110,7 +110,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
   }
 
   // Delete the tested application
-  cy.deleteApp({appName: appName});
+  // cy.deleteApp({appName: appName});
 });
 
 // Configurations tests

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -110,7 +110,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
   }
 
   // Delete the tested application
-  // cy.deleteApp({appName: appName});
+  cy.deleteApp({appName: appName});
 });
 
 // Configurations tests


### PR DESCRIPTION
Implemented: https://github.com/epinio/epinio-end-to-end-tests/issues/359

## Done
- Adapted already existing test to use commit redeploy logic in 1 case instead of 2 source updates
- Added test coverage for commit redeployment functionality
- Renamed test title

## Tests
[STD UI experimental template #164](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5584701631/jobs/10206452544)
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/c5c0917e-0a07-4cfa-9cb2-1a762fea9cec)

