### PR TITLE
Cypress/reviewing menu tests

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -27,7 +27,7 @@ describe('Menu testing', () => {
     epinio.checkEpinioNav();
   });
 
-  it.skip('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
+  it('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
     cy.deleteAll('Namespaces');
     cy.clickEpinioMenu('Dashboard');
     cy.checkDashboardResources({ namespaceNumber: '0' });
@@ -35,7 +35,7 @@ describe('Menu testing', () => {
     cy.createNamespace('workspace');
   });
 
-  it.skip('Check "About" page and main links', { tags: '@menu-3' }, () => {
+  it('Check "About" page and main links', { tags: '@menu-3' }, () => {
     // Check link on main page to about page, then goes there and check more links
     cy.checkLink('v', '/epinio/c/default/about', 'about', false);
     cy.checkLink('Epinio', 'https://github.com/epinio/epinio');
@@ -44,8 +44,11 @@ describe('Menu testing', () => {
     cy.aboutPageFunction({ compareVersionVsMainPage: true });
 
     // Returns to about page, refresh and checks 'Back' turns into 'Home'
-    cy.checkLink('v', '/epinio/c/default/about', 'about', false);
-    cy.reload();
+    cy.checkLink('v', '/epinio/c/default/about', 'about', false).then(() => {
+      cy.log('Reloading Page')
+      cy.reload({ timeout: 20000} );
+    })
+    
     cy.checkElementVisibility('.back-link', 'Home')
   });
 
@@ -66,6 +69,7 @@ describe('Menu testing', () => {
     cy.clickButton('Deploy Application');
     cy.checkElementVisibility('[data-testid="epinio_app-source_type"]', 'Folder');
     cy.go('back');
+    cy.checkElementVisibility('body', 'Create Instance');
     cy.clickButton('Create Instance');
     cy.checkElementVisibility('body', 'Catalog Service');
     cy.go('back');

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -27,7 +27,7 @@ describe('Menu testing', () => {
     epinio.checkEpinioNav();
   });
 
-  it('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
+  it.skip('Verify Welcome Screen without Namespaces', { tags: '@menu-2' }, () => {
     cy.deleteAll('Namespaces');
     cy.clickEpinioMenu('Dashboard');
     cy.checkDashboardResources({ namespaceNumber: '0' });
@@ -35,7 +35,7 @@ describe('Menu testing', () => {
     cy.createNamespace('workspace');
   });
 
-  it('Check "About" page and main links', { tags: '@menu-3' }, () => {
+  it.skip('Check "About" page and main links', { tags: '@menu-3' }, () => {
     // Check link on main page to about page, then goes there and check more links
     cy.checkLink('v', '/epinio/c/default/about', 'about', false);
     cy.checkLink('Epinio', 'https://github.com/epinio/epinio');

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -44,10 +44,14 @@ describe('Menu testing', () => {
     cy.aboutPageFunction({ compareVersionVsMainPage: true });
 
     // Returns to about page, refresh and checks 'Back' turns into 'Home'
-    cy.checkLink('v', '/epinio/c/default/about', 'about', false).then(() => {
-      cy.log('Reloading Page')
-      cy.reload({ timeout: 20000} );
-    })
+    cy.checkLink('v', '/epinio/c/default/about', 'about', false)
+    // Adding wait because reloads may break severely rest of tests
+    // if executed before previous comand is completed
+    cy.wait(10000)
+    
+    cy.log('Reloading Page')
+    cy.reload({ timeout: 20000} );
+    
     
     cy.checkElementVisibility('.back-link', 'Home')
   });

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -319,8 +319,13 @@ Cypress.Commands.add('checkLink', (nameInLink, url, checkLandingLocator, goBack=
   expect(response.body).to.have.length.greaterThan(100)
   
   if (checkLandingLocator){
-    cy.contains('a', nameInLink, { matchCase: false }).click()
-    cy.contains(checkLandingLocator, { matchCase: false }).should('be.visible');
+    // cy.contains('a', nameInLink, { matchCase: false }).click()
+    // cy.contains(checkLandingLocator, { matchCase: false }).should('be.visible');
+    cy.contains('a', nameInLink, { matchCase: false }).click().then(() => {
+      cy.log('Checking landing locator')
+      cy.contains(checkLandingLocator, { matchCase: false }).should('be.visible');
+    })
+    
     // Return to previous page if true (default)
     if (goBack === true){
       cy.go('back'); 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -65,7 +65,7 @@ Cypress.Commands.add('dexLogin', (username = 'admin@epinio.io', password = 'pass
   cy.get('#submit-login').click();
   // Checking redirection to landing page is correct and Dex user is present
   if (checkLandingPage == true) {
-    cy.contains('Welcome to Epinio').should('be.visible')
+    cy.contains('Welcome to Epinio', {timeout: 20000}).should('be.visible')
     cy.get('.user-image.text-right.hand', {timeout: 5000}).click().then(() => {
       cy.contains('admin@epinio.io');})}
 })
@@ -323,7 +323,7 @@ Cypress.Commands.add('checkLink', (nameInLink, url, checkLandingLocator, goBack=
     // cy.contains(checkLandingLocator, { matchCase: false }).should('be.visible');
     cy.contains('a', nameInLink, { matchCase: false }).click().then(() => {
       cy.log('Checking landing locator')
-      cy.contains(checkLandingLocator, { matchCase: false }).should('be.visible');
+      cy.contains(checkLandingLocator, { matchCase: false, timeout: 30000 }).should('be.visible');
     })
     
     // Return to previous page if true (default)


### PR DESCRIPTION
Stabilizes menu tests.

Done:

- Adding explicit wait of 10 s before reload. This is done because Cypress did not wait for the previous command to be ended and launched reload almost at the same time. This caused severe problems leaving Cypress hanging for rest of tests at times.
- Adding implicit waits for elements 

Tests done:
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5753679141
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5755425779

