### PR TITLE
Deploy app on s3gw

### DIFF
--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -33,6 +33,16 @@ on:
         description: Runner on which to execute tests
         required: true
         type: string
+      grep_test_by_tag:
+        description: Grep tags. For multiple selection separate with spaces
+        required: false
+        type: string
+        default: ''
+      s3_store_type:
+        description: Select s3Storage type for installation (s3gw, s3, <none> = minio)
+        required: false
+        type: string
+        default: ''
 
 jobs:
   installation:
@@ -98,6 +108,7 @@ jobs:
         S3_KEY_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
         UI: rancher
+        S3_STORE_TYPE: ${{ inputs.s3_store_type }}
         # EXTRAENV_NAME: SESSION_KEY
         # EXTRAENV_VALUE: 12345
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
@@ -209,6 +220,7 @@ jobs:
         SYSTEM_DOMAIN: ${{ needs.installation.outputs.MY_IP }}.omg.howdoi.website
         # set UI value to something else than 'rancher'
         UI: epinio-rancher
+        GREPTAGS: ${{ inputs.grep_test_by_tag }}
       options: --add-host ${{ needs.installation.outputs.MY_HOSTNAME }}:${{ needs.installation.outputs.MY_IP }} --ipc=host ${{ inputs.docker_options }}
     steps:
       - name: Cypress run

--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -18,3 +18,17 @@ jobs:
       cypress_test: menu.spec.ts
       runner: ui-e2e-0
     secrets: inherit
+
+  rancher-chrome-s3gw:
+    # Epinio installation with s3gw and with simple app deployment '@appl-1' test only
+    # It should be triggered on different runner than the other job to speed it up
+    uses: ./.github/workflows/master_rancher_ui_workflow.yml
+    with:
+      browser: chrome
+      cypress_image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+      cypress_install_test: installation.spec.ts
+      cypress_test: applications.spec.ts
+      grep_test_by_tag: @appl-1
+      s3_store_type: s3gw
+      runner: ui-e2e
+    secrets: inherit

--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -28,7 +28,7 @@ jobs:
       cypress_image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
       cypress_install_test: installation.spec.ts
       cypress_test: applications.spec.ts
-      grep_test_by_tag: @appl-1
+      grep_test_by_tag: '@appl-1'
       s3_store_type: s3gw
       runner: ui-e2e
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 cypress/videos/*
 cypress/screenshots/*
 cypress/downloads/*
+mochawesome-report/*

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   viewportWidth: 1314,
   viewportHeight: 954,
+  video: false,
   defaultCommandTimeout: 10000,
   pageLoadTimeout:30000,
   // numTestsKeptInMemory:25,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   viewportWidth: 1314,
   viewportHeight: 954,
-  video: false,
+  // video: false,
   defaultCommandTimeout: 10000,
   pageLoadTimeout:30000,
   // numTestsKeptInMemory:25,

--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -13,7 +13,7 @@ describe('Epinio installation testing', () => {
     cy.get('.clusters').contains(Cypress.env('cluster')).click()
   });
 
-  it.skip('Add the Epinio helm repo', () => {
+  it('Add the Epinio helm repo', () => {
     if (Cypress.env('experimental_chart_branch') != null) {
       cy.allowRancherPreReleaseVersions();
       cy.addHelmRepo({ repoName: 'epinio-experimental', repoUrl: 'https://github.com/epinio/charts.git', repoType: 'git', branchName: Cypress.env('experimental_chart_branch') });

--- a/cypress/e2e/unit_tests/installation.spec.ts
+++ b/cypress/e2e/unit_tests/installation.spec.ts
@@ -13,7 +13,7 @@ describe('Epinio installation testing', () => {
     cy.get('.clusters').contains(Cypress.env('cluster')).click()
   });
 
-  it('Add the Epinio helm repo', () => {
+  it.skip('Add the Epinio helm repo', () => {
     if (Cypress.env('experimental_chart_branch') != null) {
       cy.allowRancherPreReleaseVersions();
       cy.addHelmRepo({ repoName: 'epinio-experimental', repoUrl: 'https://github.com/epinio/charts.git', repoType: 'git', branchName: Cypress.env('experimental_chart_branch') });
@@ -24,31 +24,19 @@ describe('Epinio installation testing', () => {
     }
   });
 
-  it('Install Epinio with s3gw, check ingress over URL and uninstall it', () => {
-    if (Cypress.env('experimental_chart_branch') != null) {
-      cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false, namespace: 'None' });
-    }
-    else {
-      // Boolean must be forced to false otherwise code is failing
-      cy.epinioInstall({ s3: false, s3gw: true, extRegistry: false });
-    }
-    cy.checkEpinioInstallationRancher();
-    cy.visit('/c/local/explorer#cluster-events');
-    cy.epinioUninstall();
-  });
-
   it('Install Epinio', () => {
     if (Cypress.env('experimental_chart_branch') != null) {
-      cy.epinioInstall({ s3: false, extRegistry: false, namespace: 'None' });
+      cy.epinioInstall({ s3Storage: Cypress.env('s3Storage'), extRegistry: false, namespace: 'None' });
     }
     else {
       // Boolean must be forced to false otherwise code is failing
-      cy.epinioInstall({ s3: false, extRegistry: false });
+      cy.epinioInstall({ s3Storage: Cypress.env('s3Storage'), extRegistry: false });
     }
   });
 
   it('Verify Epinio over ingress URL', () => {
     cy.checkEpinioInstallationRancher();
+    cy.visit('/c/local/explorer#cluster-events');
   });
   
 });

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -18,6 +18,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.system_domain = process.env.SYSTEM_DOMAIN;
   config.env.cors = process.env.CORS;
   config.env.cache_session = process.env.CACHE_SESSION || false;
+  config.env.s3Storage = process.env.S3_STORE_TYPE;
   config.env.external_reg_username = process.env.EXT_REG_USER;
   config.env.external_reg_password = process.env.EXT_REG_PASSWORD;
   config.env.s3_key_id = process.env.S3_KEY_ID;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -50,7 +50,7 @@ declare global {
       allowRancherPreReleaseVersions(): Chainable<Element>;
       addHelmRepo(repoName: string, repoUrl: string, repoType?: string, branchName?: string,): Chainable<Element>;
       removeHelmRepo(repoName?: string,): Chainable<Element>;
-      epinioInstall(s3?: boolean, s3gw?: boolean, extRegistry?: boolean, namespace?: string): Chainable<Element>;
+      epinioInstall(s3Storage?: string, extRegistry?: boolean, namespace?: string): Chainable<Element>;
       createService(serviceName: string, catalogType: string): Chainable<Element>;
       bindServiceFromSevicesPage(appName: string, serviceName: string, bindingOption?: string): Chainable<Element>;
       deleteService(serviceName: string): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1298,7 +1298,7 @@ Cypress.Commands.add('epinioInstall', ({ s3Storage, extRegistry, namespace = 'ep
       cy.contains('S3 use SSL').click();
       break;
     default:
-     cy.log('Using default s3Storage (Minio)');
+      cy.log('Using default s3Storage (Minio)');
   }
 
   // Add ExtraEnv values on bottom of values yaml if present, careful here, editor does indentation

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1222,7 +1222,7 @@ Cypress.Commands.add('addHelmRepo', ({ repoName, repoUrl, repoType, branchName =
 });
 
 // Install Epinio via Helm
-Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespace = 'epinio-install' }) => {
+Cypress.Commands.add('epinioInstall', ({ s3Storage, extRegistry, namespace = 'epinio-install' }) => {
   cy.clickClusterMenu(['Apps', 'Charts']);
 
   // Make sure we are in the chart screen (test failed here before)
@@ -1235,7 +1235,7 @@ Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespac
     // Close the namespaces dropdown
     cy.get('.top > .ns-filter > .ns-dropdown.ns-open').click({ force: true });
   // Reload to ensure installed apps are refreshed
-    cy.reload()
+  //  cy.reload()
 
   cy.get('a[href="/dashboard/c/local/apps/catalog.cattle.io.app"] > span.count', {timeout: 20000}).then(($el) => {
     if ($el.text().trim() == '0') {
@@ -1281,21 +1281,24 @@ Cypress.Commands.add('epinioInstall', ({ s3, s3gw = false, extRegistry, namespac
     cy.typeValue({label: 'External registry namespace', value: Cypress.env('external_reg_username'), log: false});
   }
 
-  if (s3gw == true) {
-    cy.contains('a', 'S3 storage').click();
-    cy.contains('Install Minio').click();
-    cy.contains('Install s3gw').should('be.visible').click();
-    };
-
-  // Configure s3 storage
-  if (s3 === true) {
-    cy.contains('a', 'External S3 storage').click();
-    cy.contains('Use an external s3 storage').click();
-    cy.typeValue({label: 'S3 endpoint', value: 's3.amazonaws.com'});
-    cy.typeValue({label: 'S3 access key id', value: Cypress.env('s3_key_id'), log: false});
-    cy.typeValue({label: 'S3 access key secret', value: Cypress.env('s3_key_secret'), log: false});
-    cy.typeValue({label: 'S3 bucket', value: 'epinio-ci'});
-    cy.contains('S3 use SSL').click();
+  switch (s3Storage) {
+    case 's3gw':
+      cy.contains('a', 'S3 storage').click();
+      cy.contains('Install Minio').click();
+      cy.contains('Install s3gw').should('be.visible').click();
+      break;
+    case 's3':
+      // Configure external AWS S3 storage
+      cy.contains('a', 'S3 storage').click();
+      cy.contains('Install Minio').click();
+      cy.typeValue({label: 'S3 endpoint', value: 's3.amazonaws.com'});
+      cy.typeValue({label: 'S3 access key id', value: Cypress.env('s3_key_id'), log: false});
+      cy.typeValue({label: 'S3 access key secret', value: Cypress.env('s3_key_secret'), log: false});
+      cy.typeValue({label: 'S3 bucket', value: 'epinio-ci'});
+      cy.contains('S3 use SSL').click();
+      break;
+    default:
+     cy.log('Using default s3Storage (Minio)');
   }
 
   // Add ExtraEnv values on bottom of values yaml if present, careful here, editor does indentation

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1234,8 +1234,8 @@ Cypress.Commands.add('epinioInstall', ({ s3Storage, extRegistry, namespace = 'ep
     cy.get('#all_user', { timeout: 2000 }).contains('Only User Namespaces').should('be.visible').click();
     // Close the namespaces dropdown
     cy.get('.top > .ns-filter > .ns-dropdown.ns-open').click({ force: true });
-  // Reload to ensure installed apps are refreshed
-  //  cy.reload()
+    // Reload to ensure installed apps are refreshed
+    cy.reload()
 
   cy.get('a[href="/dashboard/c/local/apps/catalog.cattle.io.app"] > span.count', {timeout: 20000}).then(($el) => {
     if ($el.text().trim() == '0') {


### PR DESCRIPTION
ref: https://github.com/epinio/epinio-end-to-end-tests/issues/361

* `installEpinio` function modifed, now it accepts optional `s3Storage: Cypress.env('s3Storage')` string values `s3gw`, `s3`, and "" aka `none` , booleans args for setting `s3` and `s3gw` were removed
* fixed also selector for aws `s3` in the same function but it is not used anywhere (but works, can be used in https://github.com/epinio/epinio-end-to-end-tests/issues/236)
* existing workflow for `Rancher-UI-1-Chrome` extended for triggering another job related to s3gw where only `applications.spec.ts` with tag `@appl-1` (simplest app depoloyment test) is used
* the workflow is using different runner classes for the jobs so it should not slow down the execution time (jobs are running in parallel)

Testrun: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/5832019579

Command used for the test development and testing (only installation.spec.ts part in rancher):
```bash
S3_STORE_TYPE=s3gw CACHE_SESSION=true CORS=1.2.3.4.nip.io UI=rancher CLUSTER_NAME=local \
SYSTEM_DOMAIN=1.2.3.4.nip.io RANCHER_USER=admin RANCHER_PASSWORD=[SECRET] \
RANCHER_URL=https://1.2.3.4.nip.io/dashboard EPINIO_PASSWORD=[SECRET] \
npx cypress run --config-file=cypress.config.ts -b chromium --headed --spec cypress/e2e/unit_tests/installation.spec.ts
```