### PR TITLE
Cypress/369 fix flaky tests

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -70,6 +70,7 @@ describe('Menu testing', () => {
     cy.clickButton('Create Namespace');
     cy.checkElementVisibility('.btn.role-secondary.mr-10', 'Cancel');
     cy.go('back');
+    cy.checkElementVisibility('body', 'Deploy Application');
     cy.clickButton('Deploy Application');
     cy.checkElementVisibility('[data-testid="epinio_app-source_type"]', 'Folder');
     cy.go('back');

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -117,6 +117,8 @@ Cypress.Commands.add('deleteAll', (label) => {
   }
   else {
     cy.clickEpinioMenu(label)
+    // Ensuring table is loaded prior further deletion steps
+    cy.get('table.sortable-table.top-divider').should('contain.text', 'Name');
     cy.get('h1',{timeout: 35000}).contains(label).should('be.visible')
   };
   cy.log(`## DElETION OF ALL ${label} STARTS HERE ##`)

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -274,6 +274,9 @@ Cypress.Commands.add('updateAppSource', ({ name, sourceType, archiveName, gitUse
   // Open 3 dots button
   cy.open3dotsMenu({ name: name, selection: 'Edit Config'})
 
+  // Check for source page to be visible
+  cy.checkElementVisibility('body', 'Provide the source');
+
   // Select source update desired
   cy.selectSourceType({ sourceType: sourceType, archiveName: archiveName, gitUsername: gitUsername , gitRepo: gitRepo, gitBranch: gitBranch, gitCommit: gitCommit });
   cy.clickButton('Update Source');


### PR DESCRIPTION
Fixes: https://github.com/epinio/epinio-end-to-end-tests/issues/369

Added implicit waits to mitigate flakiness on various tests

Results:
[CI menu test](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6012171051/job/16307002132#step:14:69): passing now 
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/dc3413b3-cea9-431a-8ee4-5f5db40cdf26)

[Applications tests](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6023922705/job/16341601754#step:14:71) errors related to flakiness seem ok now:
- 'Push Gitlab app, redeploy from commit and update sources' test 
- 'Download app export data' test passing on offending point. Current failure is legit caused by timeout in export time
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/c110861b-7426-478f-a794-91033f4731ce)
