### PR TITLE
Adapting string to small cap in "namespace"

### DIFF
--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -847,7 +847,7 @@ Cypress.Commands.add('createNamespaceFromResource', (namespace) => {
 
     // Open Namespace dropdown and select new Namespace
     cy.get('div.vs__selected-options').eq(0).click()
-    cy.get('li.vs__dropdown-option').contains('Create a New Namespace').click({force: true})
+    cy.get('li.vs__dropdown-option').contains('Create a new Namespace').click({force: true})
     // Add Namespace and rest of values
     cy.typeValue({label: 'Namespace', value: namespace});
     cy.get("input[placeholder='A unique name']").type(`samplename-${namespace}`)


### PR DESCRIPTION
Adapting namespace [failed test](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6080085442/job/16495441908#step:14:62) from `Create a New Namespace` to new string without capitalization `Create a new Namespace`: 

![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/9fa4f0ea-42e3-44ee-ae15-c7be88150aaa)

CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6081336751