### PR TITLE
Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ install-k3s: ## Install K3s with default options
 	## Wait for K3s to start (could be improved?)
 	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"
 
-install-cert-manager: ## Install dependencies needed by Epinio
-	@./scripts/install_cert-manager.sh
-
 install-epinio: ## Install Epinio with Helm
 	@./scripts/install_epinio.sh
 
@@ -88,12 +85,13 @@ delete-cluster:
 	k3d cluster delete $(CLUSTER_NAME)
 
 install-cert-manager:
-	kubectl create namespace cert-manager
 	helm repo add jetstack https://charts.jetstack.io
 	helm repo update
-	helm install cert-manager --namespace cert-manager jetstack/cert-manager \
+	helm upgrade --install cert-manager --namespace cert-manager jetstack/cert-manager \
+		--create-namespace \
 		--set installCRDs=true \
-		--set extraArgs[0]=--enable-certificate-owner-ref=true
+		--set extraArgs[0]=--enable-certificate-owner-ref=true \
+		--wait
 
 deploy-epinio:
 	helm repo add epinio https://epinio.github.io/helm-charts

--- a/scripts/install_cert-manager.sh
+++ b/scripts/install_cert-manager.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-# Install cert-manager
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-helm upgrade --install cert-manager jetstack/cert-manager -n cert-manager --create-namespace --set installCRDs=true --set extraArgs[0]=--enable-certificate-owner-ref=true --wait

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -74,11 +74,8 @@ if [[ -z $EPINIO_VERSION ]]; then
 fi
 
 # Show Epinio info, could be useful for debugging
-sleep 20
+kubectl wait pods -n epinio -l app.kubernetes.io/name=epinio-server --for=condition=ready --timeout=2m
 dist/epinio-* login -u admin -p password --trust-ca https://epinio.${EPINIO_SYSTEM_DOMAIN}
-
-# Wait a little before getting informations, otherwise we can have a 502 code
-sleep 20
 dist/epinio-* info
 
 # Go back to the previous directory

--- a/scripts/patch_epinio-ui.sh
+++ b/scripts/patch_epinio-ui.sh
@@ -5,3 +5,4 @@ set -ex
 # Patch the epinio-ui deployment with latest dev image
 # The image is building by https://github.com/epinio/ui-backend/actions/workflows/release-next.yml
 kubectl set image -n epinio deployment/epinio-ui epinio-ui=ghcr.io/epinio/epinio-ui:latest-next
+kubectl wait pods -n epinio -l app.kubernetes.io/name=epinio-ui --for=condition=ready --timeout=2m


### PR DESCRIPTION
Mainly cleanup but the changes will save ~40s for E deploment
* sleep after patching `epinio-server` pod replaced by waiting for resource
* sleep between `login` and `info` removed
* removed duplicated `install-cert-manager` target
* added wait for `epinio-ui` pod resource after ui patching to `latest-next`

Tested locally by `make install-k3s install-cert-manager install-epinio patch-epinio-ui`