### PR TITLE
Always (re)pull epinio-ui:latest-next

### DIFF
--- a/scripts/patch_epinio-ui.sh
+++ b/scripts/patch_epinio-ui.sh
@@ -3,6 +3,7 @@
 set -ex
 
 # Patch the epinio-ui deployment with latest dev image
-# The image is building by https://github.com/epinio/ui-backend/actions/workflows/release-next.yml
+# The image is building by https://github.com/epinio/ui/actions/workflows/release-next.yml
 kubectl set image -n epinio deployment/epinio-ui epinio-ui=ghcr.io/epinio/epinio-ui:latest-next
+kubectl patch deployment epinio-ui -n epinio -p '{"spec":{"template":{"spec":{"containers":[{"name":"epinio-ui", "imagePullPolicy":"Always"}]}}}}'
 kubectl wait pods -n epinio -l app.kubernetes.io/name=epinio-ui --for=condition=ready --timeout=2m


### PR DESCRIPTION
Once you delete the epinio-ui pod it will repull the image.

* doesn't have an impact on CI. This will just set `imagePullPolicy` to `Always` in UI deployment to prevent using outdated image within `make patch-epinio-ui` - if the image has been changed already you will have to delete the ui pod manually anyway.
* updated link to release-next workflow