### PR TITLE
Fix wait after patching imagePullPolicy

### DIFF
--- a/scripts/patch_epinio-ui.sh
+++ b/scripts/patch_epinio-ui.sh
@@ -5,5 +5,6 @@ set -ex
 # Patch the epinio-ui deployment with latest dev image
 # The image is building by https://github.com/epinio/ui/actions/workflows/release-next.yml
 kubectl set image -n epinio deployment/epinio-ui epinio-ui=ghcr.io/epinio/epinio-ui:latest-next
+kubectl wait pods -n epinio -l app.kubernetes.io/name=epinio-ui --for=condition=ready --timeout=2m
 kubectl patch deployment epinio-ui -n epinio -p '{"spec":{"template":{"spec":{"containers":[{"name":"epinio-ui", "imagePullPolicy":"Always"}]}}}}'
 kubectl wait pods -n epinio -l app.kubernetes.io/name=epinio-ui --for=condition=ready --timeout=2m


### PR DESCRIPTION
I had to duplicate the `wait` to make it work again.

Testrun: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6097296605
spec: `menu`
grep tags: `@menu-1` (well I entered wrong value `@menu1` but doesn't matter, the affected part is executed earlier than cy)