### PR TITLE
Cypress/change runners

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -33,7 +33,7 @@ on:
           default: menu.spec.ts
         runner:
           description: Runner on which to execute tests
-          default: ui-e2e-2
+          default: self-hosted
           required: true
           type: string
         docker_options:

--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -45,7 +45,7 @@ on:
           description: Choose rancher version to deploy
           required: true
           type: string
-          default: '2.7.3'
+          default: '2.7.6'
 
 jobs:
   installation:

--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -16,7 +16,7 @@ jobs:
       cypress_install_test: installation.spec.ts
       # cypress_test: with_default_options.spec.ts
       cypress_test: menu.spec.ts
-      runner: ui-e2e-0
+      runner: self-hosted
     secrets: inherit
 
   rancher-chrome-s3gw:
@@ -30,5 +30,5 @@ jobs:
       cypress_test: applications.spec.ts
       grep_test_by_tag: '@appl-1'
       s3_store_type: s3gw
-      runner: ui-e2e
+      runner: self-hosted
     secrets: inherit

--- a/.github/workflows/scenario_2_firefox_rancher_ui.yml
+++ b/.github/workflows/scenario_2_firefox_rancher_ui.yml
@@ -19,6 +19,6 @@ jobs:
       # Due to security reason, Firefox can't be started as root
       # https://github.com/cypress-io/github-action#firefox
       docker_options: '--user 1000'
-      runner: ui-e2e-2
+      runner: self-hosted
       # ext_reg: '1'
     secrets: inherit


### PR DESCRIPTION
Changing runners to be hard-coded to dynamic selection using tag `self-hosted`

Tests:
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6158121095/job/16710602613

![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/b85d8440-7fd1-45cf-87bf-1f4aa7139747)

Before (failing):
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6156647276