### PR TITLE
Switching default runner for rancher tests

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -33,7 +33,7 @@ on:
           default: menu.spec.ts
         runner:
           description: Runner on which to execute tests
-          default: ui-e2e-2
+          default: ui-e2e-3
           required: true
           type: string
         docker_options:

--- a/.github/workflows/scenario_2_firefox_rancher_ui.yml
+++ b/.github/workflows/scenario_2_firefox_rancher_ui.yml
@@ -19,6 +19,6 @@ jobs:
       # Due to security reason, Firefox can't be started as root
       # https://github.com/cypress-io/github-action#firefox
       docker_options: '--user 1000'
-      runner: ui-e2e-2
+      runner: ui-e2e-3
       # ext_reg: '1'
     secrets: inherit


### PR DESCRIPTION
Changing default runner `ui-e2e-2` (faulty at times) to `ui-e2e-3`
CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6160083136/job/16716218177