### PR TITLE
Implementing cy.then before reload on menu tests

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -51,9 +51,10 @@ describe('Menu testing', () => {
     
     cy.log('Reloading Page')
     cy.reload({ timeout: 20000} );
-    
-    
+    // Adding 'then' to execute only after previous command is completed
+    cy.then(() => {
     cy.checkElementVisibility('.back-link', 'Home')
+    })
   });
 
 


### PR DESCRIPTION
Helps / fixes: https://github.com/epinio/epinio-end-to-end-tests/issues/378

## Done
Added `cy.then` before a reload to ensure this one ends completely.
This seems to have eased the flakiness on subsequent tests both for Rancher and STD_UI: 

- [Rancher-UI-2-Firefox #745](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6171514597/job/16750279071#step:3:74)
- [STD-UI-Latest-Chrome #664 ](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6171828120/job/16750847610#step:14:60)