### PR TITLE
Disabling reload to avoid page crashing

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -43,18 +43,21 @@ describe('Menu testing', () => {
     // Check version between main and about page
     cy.aboutPageFunction({ compareVersionVsMainPage: true });
 
-    // Returns to about page, refresh and checks 'Back' turns into 'Home'
-    cy.checkLink('v', '/epinio/c/default/about', 'about', false)
-    // Adding wait because reloads may break severely rest of tests
-    // if executed before previous comand is completed
-    cy.wait(10000)
+    // TEMPORARY DISABLING REFRESH AND CHECK BACK DUE TO NS_ERROR_UNEXPECTED
+    // IT LEAVES CYPRESS IN A HANGING STATE BREAKING OTHER TESTS
+
+    // // Returns to about page, refresh and checks 'Back' turns into 'Home'
+    // cy.checkLink('v', '/epinio/c/default/about', 'about', false)
+    // // Adding wait because reloads may break severely rest of tests
+    // // if executed before previous comand is completed
+    // cy.wait(10000)
     
-    cy.log('Reloading Page')
-    cy.reload({ timeout: 20000} );
-    // Adding 'then' to execute only after previous command is completed
-    cy.then(() => {
-    cy.checkElementVisibility('.back-link', 'Home')
-    })
+    // cy.log('Reloading Page')
+    // cy.reload({ timeout: 20000} );
+    // // Adding 'then' to execute only after previous command is completed
+    // cy.then(() => {
+    // cy.checkElementVisibility('.back-link', 'Home')
+    // })
   });
 
 


### PR DESCRIPTION
Temporarily disabling reloading on specific test `Check "About" page and main links` to avoid page crashing and at times subsequent malfunctioning on other tests

Example

![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/63dce674-d04a-434f-aa0c-618ce6890181)
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/3151fe7c-53ff-4182-8d35-ae4fd0a1580f)

CI: 
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6219596390/job/16877965897