### PR TITLE
spacing cron jobs

### DIFF
--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '30 2 * * *'
 
 jobs:
   rancher-chrome:

--- a/.github/workflows/std_ui_latest_firefox.yml
+++ b/.github/workflows/std_ui_latest_firefox.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
 
 jobs:
 # I keep the following tests commented out in case someone want to enable them later.


### PR DESCRIPTION
Spacing cron times on 2 workflows to better ensure no API calls overlap between workflows.

After change timing will be as follows:

- `scenario_2_firefox_rancher_ui.yml`: 2:00
- `scenario_1_chrome_rancher_ui.yml`: 2:30 (updated, used to be 2:00)
- `std_ui_latest_firefox.yaml`: 3:00 (updated, used to be 2:00)
- `std_ui_latest_chrome.yaml`: 4:00