### PR TITLE
WORKAROUND: epinio-staging-scripts using epinio-unpacker:latest

### DIFF
--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -66,6 +66,10 @@ helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHAR
 # Wait for Epinio deployment to be ready
 kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 
+# WORKAROUND: should be removed once the image retention issue is fixed, ref https://github.com/epinio/epinio/issues/2583
+# Temporary fix for unavailable epinio-unpacker:v1.10.0-rc1 image
+kubectl patch configmap -n epinio epinio-stage-scripts -p '{"data":{"unpackImage":"ghcr.io/epinio/epinio-unpacker:latest"}}'
+
 # Patch Epinio pod if no targeting specific versions
 # mandatory to use the 'main' version!
 if [[ -z $EPINIO_VERSION ]]; then

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -66,9 +66,8 @@ helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHAR
 # Wait for Epinio deployment to be ready
 kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 
-# WORKAROUND: should be removed once the image retention issue is fixed, ref https://github.com/epinio/epinio/issues/2583
-# Temporary fix for unavailable epinio-unpacker:v1.10.0-rc1 image
-kubectl patch configmap -n epinio epinio-stage-scripts -p '{"data":{"unpackImage":"ghcr.io/epinio/epinio-unpacker:latest"}}'
+# "Uncomment this if tests fails due to missing unpacker manifest as in https://github.com/epinio/epinio/issues/2583 "
+# kubectl patch configmap -n epinio epinio-stage-scripts -p '{"data":{"unpackImage":"ghcr.io/epinio/epinio-unpacker:latest"}}'
 
 # Patch Epinio pod if no targeting specific versions
 # mandatory to use the 'main' version!

--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -66,7 +66,7 @@ helm upgrade --debug --wait --install -n epinio --create-namespace epinio ${CHAR
 # Wait for Epinio deployment to be ready
 kubectl rollout status deployment epinio-server -n epinio --timeout=480s
 
-# "Uncomment this if tests fails due to missing unpacker manifest as in https://github.com/epinio/epinio/issues/2583 "
+# WORKAROUND: Uncomment following line if STD-UI tests are failing due to missing epinio-unpacker image as described in https://github.com/epinio/epinio/issues/2583
 # kubectl patch configmap -n epinio epinio-stage-scripts -p '{"data":{"unpackImage":"ghcr.io/epinio/epinio-unpacker:latest"}}'
 
 # Patch Epinio pod if no targeting specific versions


### PR DESCRIPTION
This should make STD-UI tests work just by replacing unavailable epinio-unpacker:v1.10.0-rc1 (deleted by cleanup job) with latest one.

RANCHER-UI will keep failing