### PR TITLE
Let Epinio settle after deployment

### DIFF
--- a/scripts/install_epinio.sh
+++ b/scripts/install_epinio.sh
@@ -80,6 +80,8 @@ fi
 
 # Show Epinio info, could be useful for debugging
 kubectl wait pods -n epinio -l app.kubernetes.io/name=epinio-server --for=condition=ready --timeout=2m
+# Let the components settle a bit longer to prevent "error verifying credentials: error while connecting to the Epinio server: empty"
+sleep 10
 dist/epinio-* login -u admin -p password --trust-ca https://epinio.${EPINIO_SYSTEM_DOMAIN}
 dist/epinio-* info
 


### PR DESCRIPTION
This PR is trying to prevent following message when doing `epinio login` just after E deployment.
```
❌  error verifying credentials: error while connecting to the Epinio server: empty
```

Testrun: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6271463380