### PR TITLE
Changing runner to avoid container init problem on previous one

### DIFF
--- a/.github/workflows/scenario_1_chrome_rancher_ui.yml
+++ b/.github/workflows/scenario_1_chrome_rancher_ui.yml
@@ -16,7 +16,7 @@ jobs:
       cypress_install_test: installation.spec.ts
       # cypress_test: with_default_options.spec.ts
       cypress_test: menu.spec.ts
-      runner: ui-e2e-0
+      runner: ui-e2e-1
     secrets: inherit
 
   rancher-chrome-s3gw:


### PR DESCRIPTION
## Done
Changing labels from `ui-e2e-0` to `ui-e2e-1` in order to succeed job `cypress-epinio-installation`, step `Initialize containers` on `rancher-chrome` test, as the current runner `gha08-runner-0`  is unhealthy as described in https://github.com/epinio/epinio/issues/2598


## CI
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6273905943
Note the difference before after changing runner:
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/e3377c18-8ce2-4165-85f7-0c2a53a313ca)

