### PR TITLE
Cypress/363 binding single step

### DIFF
--- a/cypress/e2e/unit_tests/applications.spec.ts
+++ b/cypress/e2e/unit_tests/applications.spec.ts
@@ -58,9 +58,14 @@ describe('Applications testing', () => {
     cy.runApplicationsTest('downloadChartsAndImages');
   });
 
+  it('Service bind in single step', { tags: '@appl-11' }, () => {
+    cy.runApplicationsTest('serviceBindSingleStep');
+  });
+
   // Remove skip when this is fixed: https://github.com/epinio/ui/issues/160
   it.skip('Push application with Github Source type and env vars and check it',  () => {
     cy.runApplicationsTest('gitHubAndEnvVar');
   });
+
 
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -53,6 +53,8 @@ declare global {
       epinioInstall(s3Storage?: string, extRegistry?: boolean, namespace?: string): Chainable<Element>;
       createService(serviceName: string, catalogType: string): Chainable<Element>;
       bindServiceFromSevicesPage(appName: string, serviceName: string, bindingOption?: string): Chainable<Element>;
+      createServiceAndBindOneStep(appName: string, serviceName: string[], catalogType: string[]): Chainable<Element>;
+      countAndVerifyElements(locator: string, numberRowsOrColumns: number, arrayOfElements?: boolean, text1?: string, text2?: string): Chainable<Element>;
       deleteService(serviceName: string): Chainable<Element>;
       epinioUninstall(): Chainable<Element>;
       checkEpinioInstallationRancher(): Chainable<Element>;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -54,7 +54,7 @@ declare global {
       createService(serviceName: string, catalogType: string): Chainable<Element>;
       bindServiceFromSevicesPage(appName: string, serviceName: string, bindingOption?: string): Chainable<Element>;
       createServiceAndBindOneStep(appName: string, serviceName: string[], catalogType: string[]): Chainable<Element>;
-      countAndVerifyElements(locator: string, numberRowsOrColumns: number, arrayOfElements?: boolean, text1?: string, text2?: string): Chainable<Element>;
+      countAndVerifyElements(locator: string, numberRowsOrColumns: number, text1?: string, text2?: string): Chainable<Element>;
       deleteService(serviceName: string): Chainable<Element>;
       epinioUninstall(): Chainable<Element>;
       checkEpinioInstallationRancher(): Chainable<Element>;

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1173,25 +1173,22 @@ Cypress.Commands.add('bindServiceFromSevicesPage', ({ appName, serviceName, bind
 });
 
 Cypress.Commands.add('createServiceAndBindOneStep', ({ serviceName, catalogType, appName }) => {
-  cy.get('.accordion.package.depth-0.has-children', { timeout: 20000 }).contains('Services').click()
+  cy.get('.accordion.package.depth-0.has-children', { timeout: 20000 }).contains('Services').click();
   cy.clickButton('Create');
   cy.typeValue({ label: 'Name', value: serviceName });
-  cy.get('input[placeholder="Select the type of Service to create"].vs__search').click()
-  cy.contains(catalogType).click()
+  cy.get('input[placeholder="Select the type of Service to create"].vs__search').click();
+  cy.contains(catalogType).click();
   // Verify selected catalog service is selected
   cy.get('span.vs__selected').eq(1).should('contain', catalogType)
-  /// ----------------------------------------------------------------------------- ///
-
   // Open "Bind to Applications" dropdown and bind service to app
-  // Try make this a function to be reusable
   cy.get('.v-select.inline.vs--multiple').click();
   cy.contains(appName).should('be.visible').click();
-  // Click on save button
+  // Click on create button
   cy.clickButton('Create');
   cy.get('.icon.icon-lg.icon-spinner.icon-spin', { timeout: 60000 }).contains('Creating...').should('not.exist');
   // Confirm bound application after main instance page redirection
   cy.contains('tr.main-row', serviceName, { timeout: 45000 }).within(() => {
-    cy.get('td[data-testid]', { timeout: 45000 }).eq(4).contains(appName).should('be.visible')
+    cy.get('td[data-testid]', { timeout: 45000 }).eq(4).contains(appName).should('be.visible');
   });
 });
 

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1192,20 +1192,21 @@ Cypress.Commands.add('createServiceAndBindOneStep', ({ serviceName, catalogType,
   });
 });
 
-Cypress.Commands.add('countAndVerifyElements', ({ locator, numberRowsOrColumns, text1, text2, arrayOfElements = false }) => {
+Cypress.Commands.add('countAndVerifyElements', ({ locator, numberRowsOrColumns, text1, text2 }) => {
 
   cy.get(locator).each((item, index, list) => {
     expect(list).to.have.length(numberRowsOrColumns)
 
     // This is in case several elements are to be checked per index
-    // as text1[elem-1, elem-2, elem-3,...], text2[elem-a, elem-b, elem-c,...]
-    if (arrayOfElements) {
+    // as text1[elem-1, elem-2, elem-3,...], text2[elem-a, elem-b, elem-c,...]  
+    if (Array.isArray(text1) || Array.isArray(text2)) {
+      cy.log(`Array detected? = ${Array.isArray(text1)}`)
       cy.wrap(item, { timeout: 60000 }).should('contains.text', (text1[index]))
       cy.wrap(item, { timeout: 60000 }).should('contains.text', (text2[index]))
     }
     // Here the name of checked elements will be always the same
     else {
-      cy.log('ENTERING ELSE')
+      cy.log(`Checking '${text1}' and '${text2}' in first ${numberRowsOrColumns} lines / rows`)
       cy.wrap(item, { timeout: 60000 }).should('contains.text', (text1))
       cy.wrap(item, { timeout: 60000 }).should('contains.text', (text2))
     }

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -126,7 +126,7 @@ Cypress.Commands.add('deleteAll', (label) => {
     if ($body.text().includes('Delete')) {
       cy.get('[width="30"] > .checkbox-outer-container.check').click();
       cy.get('.btn').contains('Delete').click({ctrlKey: true});
-      cy.get('#promptRemove', {timeout: 40000}).should('not.exist')
+      cy.get('#promptRemove', {timeout: 90000}).should('not.exist')
     };
   });
 });

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1172,6 +1172,49 @@ Cypress.Commands.add('bindServiceFromSevicesPage', ({ appName, serviceName, bind
   }
 });
 
+Cypress.Commands.add('createServiceAndBindOneStep', ({ serviceName, catalogType, appName }) => {
+  cy.get('.accordion.package.depth-0.has-children', { timeout: 20000 }).contains('Services').click()
+  cy.clickButton('Create');
+  cy.typeValue({ label: 'Name', value: serviceName });
+  cy.get('input[placeholder="Select the type of Service to create"].vs__search').click()
+  cy.contains(catalogType).click()
+  // Verify selected catalog service is selected
+  cy.get('span.vs__selected').eq(1).should('contain', catalogType)
+  /// ----------------------------------------------------------------------------- ///
+
+  // Open "Bind to Applications" dropdown and bind service to app
+  // Try make this a function to be reusable
+  cy.get('.v-select.inline.vs--multiple').click();
+  cy.contains(appName).should('be.visible').click();
+  // Click on save button
+  cy.clickButton('Create');
+  cy.get('.icon.icon-lg.icon-spinner.icon-spin', { timeout: 60000 }).contains('Creating...').should('not.exist');
+  // Confirm bound application after main instance page redirection
+  cy.contains('tr.main-row', serviceName, { timeout: 45000 }).within(() => {
+    cy.get('td[data-testid]', { timeout: 45000 }).eq(4).contains(appName).should('be.visible')
+  });
+});
+
+Cypress.Commands.add('countAndVerifyElements', ({ locator, numberRowsOrColumns, text1, text2, arrayOfElements = false }) => {
+
+  cy.get(locator).each((item, index, list) => {
+    expect(list).to.have.length(numberRowsOrColumns)
+
+    // This is in case several elements are to be checked per index
+    // as text1[elem-1, elem-2, elem-3,...], text2[elem-a, elem-b, elem-c,...]
+    if (arrayOfElements) {
+      cy.wrap(item, { timeout: 60000 }).should('contains.text', (text1[index]))
+      cy.wrap(item, { timeout: 60000 }).should('contains.text', (text2[index]))
+    }
+    // Here the name of checked elements will be always the same
+    else {
+      cy.log('ENTERING ELSE')
+      cy.wrap(item, { timeout: 60000 }).should('contains.text', (text1))
+      cy.wrap(item, { timeout: 60000 }).should('contains.text', (text2))
+    }
+  })
+});
+
 // Delete a Service
 Cypress.Commands.add('deleteService', ({ serviceName }) => {
   cy.get('div.header').contains('Services').click({force: true});

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -108,6 +108,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.findExtractCheck({appName: appName, exportType: 'Chart and Images'});
       break;
     case 'serviceBindSingleStep':
+      cy.deleteAll('Services')
       cy.createApp({ appName: appName, archiveName: archive, sourceType: 'Archive' });
   
       // Creates 3 services and bind app in 1 step
@@ -127,6 +128,7 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-rabbitmq-dev`, catalogType: 'rabbitmq-dev' });
       cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mongodb`, catalogType: 'mongodb-dev' });
       cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 4, text1: 'Deployed', text2: 'testapp' });
+      cy.deleteAll('Services')
       break;
   }
 

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -107,6 +107,28 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       cy.downloadManifestChartsAndImages({ appName: appName, exportType: 'Chart and Images' });
       cy.findExtractCheck({appName: appName, exportType: 'Chart and Images'});
       break;
+    case 'serviceBindSingleStep':
+      cy.createApp({ appName: appName, archiveName: archive, sourceType: 'Archive' });
+      cy.checkApp({ appName: appName, checkIcon: 'file' });
+
+      // Creates 3 services and bind app in 1 step
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-redis-dev`, catalogType: 'redis-dev' })
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mysql-dev`, catalogType: 'mysql-dev' })
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: 'svc-postgresql', catalogType: 'postgresql-dev' })
+
+      // Verifies number of deployed services and check status and app bound name
+      cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 3, text1: 'Deployed', text2: 'testapp' })
+
+      // Deletes 1 service to see if after it can be binded again
+      // Goes to service page as after deletion user is not taken there
+      cy.deleteService({ serviceName: 'svc-postgresql' })
+      cy.get('.accordion.package.depth-0.has-children', { timeout: 20000 }).contains('Services').click()
+
+      // Repeats binding in 1 step and check again
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-rabbitmq-dev`, catalogType: 'rabbitmq-dev' })
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mongodb`, catalogType: 'mongodb-dev' })
+      cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 4, text1: 'Deployed', text2: 'testapp' }) 
+      break;
   }
 
   // Delete the tested application

--- a/cypress/support/tests.ts
+++ b/cypress/support/tests.ts
@@ -109,25 +109,24 @@ Cypress.Commands.add('runApplicationsTest', (testName: string) => {
       break;
     case 'serviceBindSingleStep':
       cy.createApp({ appName: appName, archiveName: archive, sourceType: 'Archive' });
-      cy.checkApp({ appName: appName, checkIcon: 'file' });
-
+  
       // Creates 3 services and bind app in 1 step
-      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-redis-dev`, catalogType: 'redis-dev' })
-      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mysql-dev`, catalogType: 'mysql-dev' })
-      cy.createServiceAndBindOneStep({ appName: appName, serviceName: 'svc-postgresql', catalogType: 'postgresql-dev' })
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-redis-dev`, catalogType: 'redis-dev' });
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mysql-dev`, catalogType: 'mysql-dev' });
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: 'svc-postgresql', catalogType: 'postgresql-dev' });
 
       // Verifies number of deployed services and check status and app bound name
-      cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 3, text1: 'Deployed', text2: 'testapp' })
+      cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 3, text1: 'Deployed', text2: 'testapp' });
 
       // Deletes 1 service to see if after it can be binded again
       // Goes to service page as after deletion user is not taken there
-      cy.deleteService({ serviceName: 'svc-postgresql' })
-      cy.get('.accordion.package.depth-0.has-children', { timeout: 20000 }).contains('Services').click()
+      cy.deleteService({ serviceName: 'svc-postgresql' });
+      cy.get('.accordion.package.depth-0.has-children', { timeout: 20000 }).contains('Services').click();
 
       // Repeats binding in 1 step and check again
-      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-rabbitmq-dev`, catalogType: 'rabbitmq-dev' })
-      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mongodb`, catalogType: 'mongodb-dev' })
-      cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 4, text1: 'Deployed', text2: 'testapp' }) 
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-rabbitmq-dev`, catalogType: 'rabbitmq-dev' });
+      cy.createServiceAndBindOneStep({ appName: appName, serviceName: `svc-mongodb`, catalogType: 'mongodb-dev' });
+      cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 4, text1: 'Deployed', text2: 'testapp' });
       break;
   }
 


### PR DESCRIPTION
Implements: https://github.com/epinio/epinio-end-to-end-tests/issues/363

# Done
- Creates 3 services and binds to an app in 1 step
- Checks binding is ok
- Deletes one binding (from the service page)
- Creates 2 more services and binds in 1 step again
- Checks again that binding is ok

The function  `countAndVerifyElements` has 2 paramers `text1` and `text2` and  can be used in 2 ways:
- If only 1 value is set in the `text1` and `text2` it will iterate over the given number of columns / row searching for the same values. ie: here it will search on 3 rows the words `Deployed` and `testapp` to be present on each row:
```
 cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 3, text1: 'Deployed', text2: 'testapp' });
```


- If set text within array, then we can specify the exact words to search per row/column per index using brackets and separating elements by commas `[elem-1, elem-2]`. ie: here it will check for 3 rows where on row 1 should be the words `svc-1` and `testapp-1`, on row 2 `svc-2` and `testapp-2`, and so on

```
cy.countAndVerifyElements({ locator: 'tbody > tr.main-row', numberRowsOrColumns: 3, arrayOfElements=true, text1: ['svc-1' , `svc-2`, `svc-3`], text2: ['testapp-1', 'testapp-2', 'testapp-3' ] });
```

Other:
- Deletes services before and after test
- Increased timeout of deletion to 90s to prevent timeouts.

# Tests

Local:
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/6d70f084-379a-45d1-befd-1e062bd7c4c3)

CI:
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6351577125

CI after auto-detect array implementation: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6391258420/job/17346141581