### PR TITLE
Cypress/negative test login

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -108,41 +108,26 @@ describe('Menu testing', () => {
 // Note: this test needs to be adapted for Rancher Dashboard
 // Currently we are good if the custom user is unable to login when chart installed over Rancher
 // We'd need to apply values.yaml with the users first in Edit YAML
-
-describe('Login with special usernames / passwords', () => {
-  const userType = new Map([
-    ['user1', ['Hell@World', 'special']],
-    ['user2', ['Hell#@~%/=World', 'several special']],
-    ['user@test', ['Hell@World', 'standard']],
-    ['0123456789', ['password', 'standard']],
-  ]);
-
-  for (const [key, value] of userType.entries()) {
-
-    if (Cypress.env('ui') == null) {
-
-      it(`Username '${key}' & password with '${value[1]}' characters should log in`, () => {
-        cy.login(key, value[0])
-        cy.contains('Invalid username or password. Please try again.').should('not.exist')
-        cy.contains('Applications').should('be.visible')
-      })
-    }
-
-    // Login fails when installed from rancher
-    else if (Cypress.env('ui') == 'epinio-rancher' || Cypress.env('ui') == 'rancher') {
-      it(`Username '${key}' & password with '${value[1]}' characters should not log in unless values-users.yaml is applied (negative testing)`, () => {
-        cy.login(key, value[0])
-        cy.contains('Invalid username or password. Please try again.').should('exist')
-        cy.exec('echo "Negative testing for users. This user not allowed to log in unless values-users.yaml is applied."')
-      })
-    }
-
-    else {
-      throw new Error('ERROR: Variable "ui" is set to an unexpected value.')
-    }
-  };
+// For this reason we only test it in STD UI for the moment
+if (Cypress.env('ui') != 'epinio-rancher' || Cypress.env('ui') != 'rancher') {
+  describe('Login with special usernames / passwords', () => {
+    const userType = new Map([
+      ['user1', ['Hell@World', 'special']],
+      ['user2', ['Hell#@~%/=World', 'several special']],
+      ['user@test', ['Hell@World', 'standard']],
+      ['0123456789', ['password', 'standard']],
+    ]);
+  
+    for (const [key, value] of userType.entries()) {
+  
+        it(`Username '${key}' & password with '${value[1]}' characters should log in`, () => {
+          cy.login(key, value[0])
+          cy.contains('Invalid username or password. Please try again.').should('not.exist')
+          cy.contains('Applications').should('be.visible')
+        })
+    };
+  });
 }
-);
 
 describe('Login with wrong username / password is not allowed and correctly handled', () => {
   const userType = new Map([

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -144,6 +144,23 @@ describe('Login with special usernames / passwords', () => {
 }
 );
 
+describe('Login with wrong username / password is not allowed and correctly handled', () => {
+  const userType = new Map([
+    ['admin', ['wrongpassword', 'standard']],
+    ['baduser', ['password', 'standard']],
+  ]);
+
+  for (const [key, value] of userType.entries()) {
+
+    // Login fails and it is correctly handled
+    it(`Username '${key}' & password with '${value[1]}' characters should not log in`, () => {
+      cy.login(key, value[0])
+      cy.contains('Invalid username or password. Please try again.').should('exist')
+      }
+    )
+  }
+});
+
 describe('Dex testing', () => {
   it('Check Dex login works with granted access', { tags: '@dex-1' }, () => {
     cy.dexLogin('admin@epinio.io', 'password');

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -109,7 +109,7 @@ describe('Menu testing', () => {
 // Currently we are good if the custom user is unable to login when chart installed over Rancher
 // We'd need to apply values.yaml with the users first in Edit YAML
 // For this reason we only test it in STD UI for the moment
-if (Cypress.env('ui') != 'epinio-rancher' && Cypress.env('ui') != 'rancher') {
+if (Cypress.env('ui') == null) {
   describe('Login with special usernames / passwords', { tags: ['@menu-7', '@smoke'] }, () => {
     const userType = new Map([
       ['user1', ['Hell@World', 'special']],

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -61,7 +61,7 @@ describe('Menu testing', () => {
   });
 
 
-  it.skip('Check binaries, version related links and downloads from About menu', { tags: '@menu-4' }, () => {
+  it('Check binaries, version related links and downloads from About menu', { tags: '@menu-4' }, () => {
     // Go to About page
     cy.get('.version.text-muted > a').click();
     // Check binaries number, download them and chek See All Package page
@@ -110,7 +110,7 @@ describe('Menu testing', () => {
 // We'd need to apply values.yaml with the users first in Edit YAML
 // For this reason we only test it in STD UI for the moment
 if (Cypress.env('ui') != 'epinio-rancher' && Cypress.env('ui') != 'rancher') {
-  describe('Login with special usernames / passwords', () => {
+  describe('Login with special usernames / passwords', { tags: ['@menu-7', '@smoke'] }, () => {
     const userType = new Map([
       ['user1', ['Hell@World', 'special']],
       ['user2', ['Hell#@~%/=World', 'several special']],
@@ -129,7 +129,7 @@ if (Cypress.env('ui') != 'epinio-rancher' && Cypress.env('ui') != 'rancher') {
   });
 }
 
-describe('Login with wrong username / password is not allowed and correctly handled', () => {
+describe('Login with wrong username / password is not allowed and correctly handled', { tags: ['@menu-8', '@smoke'] }, () => {
   const userType = new Map([
     ['admin', ['wrongpassword', 'standard']],
     ['baduser', ['password', 'standard']],

--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -109,7 +109,7 @@ describe('Menu testing', () => {
 // Currently we are good if the custom user is unable to login when chart installed over Rancher
 // We'd need to apply values.yaml with the users first in Edit YAML
 // For this reason we only test it in STD UI for the moment
-if (Cypress.env('ui') != 'epinio-rancher' || Cypress.env('ui') != 'rancher') {
+if (Cypress.env('ui') != 'epinio-rancher' && Cypress.env('ui') != 'rancher') {
   describe('Login with special usernames / passwords', () => {
     const userType = new Map([
       ['user1', ['Hell@World', 'special']],


### PR DESCRIPTION
# Done:
- Adds negative login test to regular standalone UI tests
- Removed forced negative testing from test `Login with special usernames / passwords` in Rancher ones.
- Refactored code.

Tests:
 - [STD UI experimental template epinio/epinio#193](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6430948864/job/17462864352#step:14:74). Successful implementation. It fails due to https://github.com/epinio/ui/issues/356. Note in the screenshot how tests `Login with special usernames / passwords` remain:
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/e3c31292-1e9f-43e0-810c-bd56de2b45c1)

If tested against an Epinio version without the error it succeeds as checked locally:
![2023-10-06_13-09](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/297c2efa-11ac-4fb0-a55b-ca6d568c95ff)


- [Rancher-UI-1-Chrome epinio/epinio#791](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6453595978/job/17517759557#step:3:122). Note in the screenshot how tests `Login with special username/passwords` is now skipped /it was checking negatively earlier) but as way to handle an undesired outcome earlier:
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/f8798416-b7d3-4c05-a21a-1745e76a5d72)
