### PR TITLE
Updating wordpress version for UI tests

### DIFF
--- a/cypress/fixtures/read_from_worpress_file.txt
+++ b/cypress/fixtures/read_from_worpress_file.txt
@@ -1,4 +1,4 @@
-BP_PHP_VERSION=8.0.x
+BP_PHP_VERSION=8.1.x
 BP_PHP_SERVER=nginx
 BP_PHP_WEB_DIR=wordpress 
 DB_HOST=x8e5ee833a0f2faebaf5c4171baca-mysql

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -517,7 +517,7 @@ Cypress.Commands.add('createApp', ({appName, archiveName, sourceType, customPake
     cy.wait(500)
     // Check the entered values
     cy.get('.key > input').eq(0).should('have.value', 'BP_PHP_VERSION');
-    cy.get('.no-resize').eq(0).should('have.value', '8.0.x');
+    cy.get('.no-resize').eq(0).should('have.value', '8.1.x');
     cy.get('.key > input').eq(1).should('have.value', 'BP_PHP_SERVER');
     cy.get('.no-resize').eq(1).should('have.value', 'nginx');
     cy.get('.key > input').eq(2).should('have.value', 'BP_PHP_WEB_DIR');


### PR DESCRIPTION
Updating Wordpress version from 8.0.x to 8.1.x to avoid failures as:
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6688205013/job/18169920587#step:14:162

![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/440c8b3a-e043-4558-88ee-b25f04c61ad6)

Unblocked after https://github.com/epinio/epinio/issues/2686
---

CI: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6730558658/job/18294100107#step:14:67
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/a0fbed90-42b7-4aab-9fa8-a9d394765aca)
