### PR TITLE
Cypress / removing manual entering of CORS

### DIFF
--- a/.github/workflows/master_rancher_ui_experimental_workflow.yml
+++ b/.github/workflows/master_rancher_ui_experimental_workflow.yml
@@ -102,7 +102,7 @@ jobs:
       image: ${{ github.event.inputs.cypress_image }}
       env:
         CLUSTER_NAME: local
-        CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
+        # CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
         # Adding secrets statically
         EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}
         EXT_REG_PASSWORD: ${{ secrets.EPINIO_DOCKER_PASSWORD }}

--- a/.github/workflows/master_rancher_ui_workflow.yml
+++ b/.github/workflows/master_rancher_ui_workflow.yml
@@ -98,7 +98,7 @@ jobs:
       image: ${{ inputs.cypress_image }}
       env:
         CLUSTER_NAME: local
-        CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
+        # CORS: https://${{ needs.installation.outputs.MY_HOSTNAME }}
         EXT_REG_USER: ${{ secrets.EPINIO_DOCKER_USER }}
         EXT_REG_PASSWORD: ${{ secrets.EPINIO_DOCKER_PASSWORD }}
         RANCHER_USER: admin

--- a/cypress/support/functions.ts
+++ b/cypress/support/functions.ts
@@ -1317,7 +1317,7 @@ Cypress.Commands.add('epinioInstall', ({ s3Storage, extRegistry, namespace = 'ep
   cy.typeValue({label: 'Domain', value: Cypress.env('system_domain')});
 
   // Configure cors setting
-  cy.typeValue({label: 'Access control allow origin', value: Cypress.env('cors')});
+  // cy.typeValue({label: 'Access control allow origin', value: Cypress.env('cors')});
 
   // Configure external registry
   if (extRegistry === true) {


### PR DESCRIPTION
Removing need of typing CORS after removal of specified CORS box [here](https://github.com/epinio/helm-charts/pull/504#issuecomment-1810465891) in Rancher UI

Successful test here:
https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6892172299/job/18750492603