### PR TITLE
Cypress/disabling binary downloads until -rc tag is not present

### DIFF
--- a/cypress/e2e/unit_tests/menu.spec.ts
+++ b/cypress/e2e/unit_tests/menu.spec.ts
@@ -65,7 +65,9 @@ describe('Menu testing', () => {
     // Go to About page
     cy.get('.version.text-muted > a').click();
     // Check binaries number, download them and chek See All Package page
-    cy.aboutPageFunction({ checkBinariesNumberInAboutPage: true, downloadBinaries: true, checkSeeAllPackagePage: true })
+    // Turning to "false" options "downloadBinaries" and "checkSeeAllPackagePage" until version 1.11-rc is gone
+    // TO DO: turn back to "true" when final no rc is present
+    cy.aboutPageFunction({ checkBinariesNumberInAboutPage: true, downloadBinaries: false, checkSeeAllPackagePage: false })
   });
 
 


### PR DESCRIPTION
Setting download `downloadBinaries` and  `checkSeeAllPackagePage` to false while `-rc`tag version is out to prevent incorrect failure on test `Check binaries, version related links and downloads from About menu` as [this](https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6899066604/job/18770322994#step:3:90) one:

https://github.com/epinio/epinio-end-to-end-tests/blob/88ff5174ca52c54e446cbf76886ff03d80d0529d/cypress/e2e/unit_tests/menu.spec.ts#L70-L71

CI passing: https://github.com/epinio/epinio-end-to-end-tests/actions/runs/6900520593/job/18773805080#step:14:64
![image](https://github.com/epinio/epinio-end-to-end-tests/assets/37271841/33292c64-d345-4129-b6a7-822dc3968755)
